### PR TITLE
feat: SleepHQ API import — working client, rate-limit patience, frontend settings & sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,16 @@ CORS_ALLOWED_ORIGINS=*
 API_URL=http://localhost:8000
 API_HOST=0.0.0.0
 API_PORT=8000
+
+# ── SleepHQ API import (importer/sleephq_import.py) ──────────────────────────
+# OAuth2 credentials from https://sleephq.com/oauth/applications
+SLEEPHQ_CLIENT_ID=
+SLEEPHQ_CLIENT_SECRET=
+
+# Optional: pin to a specific team/machine instead of auto-resolving the first
+# SLEEPHQ_TEAM_ID=12345
+# SLEEPHQ_MACHINE_ID=67890
+
+# Optional: default historical date range for CLI imports
+# SLEEPHQ_FROM_DATE=2024-01-01
+# SLEEPHQ_TO_DATE=2025-01-01

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ __pycache__/
 .venv/
 venv/
 
+# uv-generated files
+uv.lock
+.python-version
+
 # Local temp / upload artifacts
 tmp/
 *.tmp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# SleepLab — Claude Context
+
+## Project structure
+- `importer/` — standalone Python scripts; run directly, not via the FastAPI app
+- `importer/db.py` — shared Postgres helpers (`get_conn`, `upsert_session`, `session_exists`, etc.)
+- `server.py` / `api/` — FastAPI backend
+- `frontend/` — React frontend
+
+## Git
+- Feature work goes on named branches (`feature/<topic>`) with one PR per feature
+- `git config` identity is set globally (`camden.bock@maine.edu` / Camden Bock) — commits work fine
+
+## Private files
+- `.newfeatures` — local implementation notes, never commit or push
+
+## Importer conventions
+- Session IDs from EDF files: `YYYYMMDD_HHMMSS`
+- Session IDs from SleepHQ: `sleephq-{record_id}` (namespaced to avoid collisions)
+- Always check `session_exists()` before upsert; use `--force` / `skip_existing=False` to overwrite
+
+## Dependencies
+- `requirements.txt` uses pinned versions for PyPI packages
+- Git-sourced deps use PEP 440 direct-reference syntax: `pkg @ git+https://...`

--- a/README.md
+++ b/README.md
@@ -313,15 +313,50 @@ You can also run the importer manually:
 
 ```bash
 cd importer
-python3.12 import_sessions.py --datalog /absolute/path/to/DATALOG --user-id <user-uuid>
+python3 import_sessions.py --datalog /absolute/path/to/DATALOG --user-id <user-uuid>
 ```
 
 Optional filters:
 
 ```bash
-python3.12 import_sessions.py --datalog /absolute/path/to/DATALOG --user-id <user-uuid> --folder 20241215
-python3.12 import_sessions.py --datalog /absolute/path/to/DATALOG --user-id <user-uuid> --from 20250101
+python3 import_sessions.py --datalog /absolute/path/to/DATALOG --user-id <user-uuid> --folder 20241215
+python3 import_sessions.py --datalog /absolute/path/to/DATALOG --user-id <user-uuid> --from 20250101
 ```
+
+## SleepHQ Import
+
+Sessions can be pulled directly from [SleepHQ](https://sleephq.com) without an SD card.
+
+### Setup
+
+Add your SleepHQ OAuth credentials and team ID in **Settings → SleepHQ Integration**, or set them in `.env`:
+
+```env
+SLEEPHQ_CLIENT_ID=your-client-id
+SLEEPHQ_CLIENT_SECRET=your-client-secret
+SLEEPHQ_TEAM_ID=your-team-id   # optional — auto-resolved if omitted
+```
+
+OAuth credentials are available from your SleepHQ developer/account settings.
+
+### Sync from the UI
+
+Open **Import → Sync from SleepHQ** and click **Sync now**. The last 30 days of sessions are fetched and written to the database. Sessions imported this way use a `sleephq-{id}` session ID to avoid collisions with SD card imports.
+
+### CLI
+
+```bash
+cd importer
+python3 sleephq_import.py --user-id <user-uuid> --days 30
+
+# Explicit date range
+python3 sleephq_import.py --user-id <user-uuid> --from 2024-01-01 --to 2025-01-01
+
+# Dry run — fetch and map without writing to the database
+python3 sleephq_import.py --user-id <user-uuid> --days 30 --dry-run
+```
+
+The importer retries automatically on rate-limit (HTTP 429) responses and pauses between paginated requests, so long historical back-fills work without manual intervention.
 
 ## AI Summaries
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -141,6 +141,15 @@ export interface DailyStat {
   session_id: string
 }
 
+export interface ImportSettings {
+  sleephq_client_id: string | null
+  sleephq_client_secret: string | null
+  sleephq_team_id: number | null
+  sleephq_machine_id: number | null
+  auto_import_sleephq: boolean
+  lookback_days: number
+}
+
 export interface SummaryStats {
   total_nights: number
   nights_with_data: number
@@ -266,6 +275,9 @@ export const api = {
   },
   finishImportUpload: (uploadId: string) => post<ImportResponse>(`/upload/datalog/${uploadId}/finish`),
   getImportStatus: () => get<ImportStatusResponse>('/upload/status'),
+  getImportSettings: () => get<ImportSettings>('/import/settings'),
+  saveImportSettings: (payload: Partial<ImportSettings>) => put<ImportSettings>('/import/settings', payload),
+  triggerSleepHQImport: () => post<{ status: string; message: string }>('/import/trigger'),
 }
 
 export const authTokenStore = {

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -4,6 +4,7 @@ import { api } from '../api/client'
 import { CheckCircleIcon } from '../components/icons/ChevronIcons'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
+import { Link } from 'react-router-dom'
 
 const IMPORT_SYNC_STORAGE_KEY = 'cpap-import-sync-active'
 
@@ -22,6 +23,11 @@ export default function Import() {
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [uploadPhase, setUploadPhase] = useState<UploadPhase>('idle')
+
+  // SleepHQ sync state
+  const [isSyncing, setIsSyncing] = useState(false)
+  const [syncMessage, setSyncMessage] = useState<string | null>(null)
+  const [syncError, setSyncError] = useState<string | null>(null)
   const [uploadedFiles, setUploadedFiles] = useState(0)
   const [totalFiles, setTotalFiles] = useState(0)
 
@@ -117,8 +123,22 @@ export default function Import() {
 
   const uploadPercent = totalFiles > 0 ? Math.round((uploadedFiles / totalFiles) * 100) : 0
 
+  async function handleSleepHQSync() {
+    setSyncError(null)
+    setSyncMessage(null)
+    setIsSyncing(true)
+    try {
+      const result = await api.triggerSleepHQImport()
+      setSyncMessage(result.message || 'Sync started. New sessions will appear shortly.')
+    } catch (err) {
+      setSyncError(err instanceof Error ? err.message : 'Sync failed')
+    } finally {
+      setIsSyncing(false)
+    }
+  }
+
   return (
-    <div className="mx-auto max-w-2xl">
+    <div className="mx-auto max-w-2xl space-y-6">
       <Card className="bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.6),_transparent_38%),var(--surface-strong)]">
         <CardHeader>
           <CardTitle className="text-2xl">Import Sleep Data</CardTitle>
@@ -189,6 +209,30 @@ export default function Import() {
               {isSubmitting ? 'Uploading...' : 'Start import'}
             </Button>
           </form>
+        </CardContent>
+      </Card>
+      <Card className="bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.45),_transparent_38%),var(--surface-strong)]">
+        <CardHeader>
+          <CardTitle className="text-2xl">Sync from SleepHQ</CardTitle>
+          <CardDescription>
+            Pull the last 30 days of CPAP sessions directly from your SleepHQ account. Configure your credentials in{' '}
+            <Link className="font-medium text-[var(--foreground)] underline underline-offset-2" to="/settings">
+              Settings
+            </Link>
+            {' '}first.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {syncMessage ? (
+            <div className="flex items-start gap-3 rounded-[20px] border border-[rgba(106,161,54,0.24)] bg-[rgba(106,161,54,0.1)] p-4 text-[var(--olive-deep)]">
+              <CheckCircleIcon className="mt-0.5 h-5 w-5 shrink-0" />
+              <p className="text-sm font-medium">{syncMessage}</p>
+            </div>
+          ) : null}
+          {syncError ? <p className="text-sm text-[var(--danger-text)]">{syncError}</p> : null}
+          <Button onClick={handleSleepHQSync} disabled={isSyncing}>
+            {isSyncing ? 'Syncing...' : 'Sync now'}
+          </Button>
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -23,6 +23,14 @@ export default function SettingsPage() {
   const [passwordError, setPasswordError] = useState<string | null>(null)
   const [isPasswordSubmitting, setIsPasswordSubmitting] = useState(false)
 
+  // SleepHQ import settings
+  const [sleephqClientId, setSleephqClientId] = useState('')
+  const [sleephqClientSecret, setSleephqClientSecret] = useState('')
+  const [sleephqTeamId, setSleephqTeamId] = useState('')
+  const [sleephqMessage, setSleephqMessage] = useState<string | null>(null)
+  const [sleephqError, setSleephqError] = useState<string | null>(null)
+  const [isSleephqSubmitting, setIsSleephqSubmitting] = useState(false)
+
   useEffect(() => {
     if (!user) {
       return
@@ -31,6 +39,16 @@ export default function SettingsPage() {
     setLastName(user.last_name)
     setEmail(user.email)
   }, [user])
+
+  useEffect(() => {
+    api.getImportSettings().then((settings) => {
+      setSleephqClientId(settings.sleephq_client_id ?? '')
+      setSleephqClientSecret(settings.sleephq_client_secret ?? '')
+      setSleephqTeamId(settings.sleephq_team_id != null ? String(settings.sleephq_team_id) : '')
+    }).catch(() => {
+      // No settings saved yet — leave fields empty
+    })
+  }, [])
 
   if (!isLoading && !user) {
     return <Navigate to="/login" replace />
@@ -81,6 +99,26 @@ export default function SettingsPage() {
       setPasswordError(err instanceof Error ? err.message : 'Could not change password')
     } finally {
       setIsPasswordSubmitting(false)
+    }
+  }
+
+  async function handleSleephqSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setSleephqError(null)
+    setSleephqMessage(null)
+    setIsSleephqSubmitting(true)
+
+    try {
+      await api.saveImportSettings({
+        sleephq_client_id: sleephqClientId || null,
+        sleephq_client_secret: sleephqClientSecret || null,
+        sleephq_team_id: sleephqTeamId ? Number(sleephqTeamId) : null,
+      })
+      setSleephqMessage('Settings saved.')
+    } catch (err) {
+      setSleephqError(err instanceof Error ? err.message : 'Could not save settings')
+    } finally {
+      setIsSleephqSubmitting(false)
     }
   }
 
@@ -185,6 +223,58 @@ export default function SettingsPage() {
 
             <Button type="submit" disabled={isPasswordSubmitting}>
               {isPasswordSubmitting ? 'Updating password...' : 'Update password'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+      <Card className="bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.45),_transparent_38%),var(--surface-strong)]">
+        <CardHeader>
+          <CardTitle className="text-2xl">SleepHQ Integration</CardTitle>
+          <CardDescription>
+            Connect your SleepHQ account to sync CPAP data automatically. You can find your OAuth credentials in your SleepHQ developer settings.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-5" onSubmit={handleSleephqSubmit}>
+            <div className="space-y-3">
+              <Label htmlFor="sleephqClientId">Client ID</Label>
+              <Input
+                id="sleephqClientId"
+                value={sleephqClientId}
+                onChange={(event) => setSleephqClientId(event.target.value)}
+                autoComplete="off"
+                placeholder="OAuth client ID from SleepHQ"
+              />
+            </div>
+
+            <div className="space-y-3">
+              <Label htmlFor="sleephqClientSecret">Client secret</Label>
+              <Input
+                id="sleephqClientSecret"
+                type="password"
+                value={sleephqClientSecret}
+                onChange={(event) => setSleephqClientSecret(event.target.value)}
+                autoComplete="new-password"
+                placeholder="OAuth client secret from SleepHQ"
+              />
+            </div>
+
+            <div className="space-y-3">
+              <Label htmlFor="sleephqTeamId">Team ID</Label>
+              <Input
+                id="sleephqTeamId"
+                value={sleephqTeamId}
+                onChange={(event) => setSleephqTeamId(event.target.value)}
+                inputMode="numeric"
+                placeholder="Your SleepHQ team ID (optional — auto-resolved if blank)"
+              />
+            </div>
+
+            {sleephqMessage ? <p className="text-sm font-medium text-[var(--olive-deep)]">{sleephqMessage}</p> : null}
+            {sleephqError ? <p className="text-sm text-[var(--danger-text)]">{sleephqError}</p> : null}
+
+            <Button type="submit" disabled={isSleephqSubmitting}>
+              {isSleephqSubmitting ? 'Saving...' : 'Save SleepHQ settings'}
             </Button>
           </form>
         </CardContent>

--- a/importer/sleephq_import.py
+++ b/importer/sleephq_import.py
@@ -1,0 +1,518 @@
+"""
+SleepHQ → Postgres bridge.
+
+Fetches per-night CPAP summaries from the SleepHQ API and upserts them
+into the sleeplab `sessions` table using the existing db helpers.
+
+Session IDs from this source are prefixed with ``sleephq-{record_id}``
+to avoid collisions with EDF-imported sessions from the same night.
+
+Environment variables (required unless passed via CLI / run_sleephq_import):
+    SLEEPHQ_CLIENT_ID       OAuth2 client ID
+    SLEEPHQ_CLIENT_SECRET   OAuth2 client secret
+    SLEEPHQ_TEAM_ID         (optional) override auto-resolved team
+    SLEEPHQ_MACHINE_ID      (optional) override auto-resolved machine
+
+CLI usage:
+    # Last 30 days
+    python sleephq_import.py --user-id <uuid> --days 30
+
+    # Explicit date range
+    python sleephq_import.py --user-id <uuid> --from 2025-01-01 --to 2025-06-01
+
+    # Dry run (no DB writes)
+    python sleephq_import.py --user-id <uuid> --days 7 --dry-run
+
+    # Re-import, overwriting existing rows
+    python sleephq_import.py --user-id <uuid> --days 7 --force
+
+Programmatic usage:
+    from sleephq_import import run_sleephq_import
+
+    stats = run_sleephq_import(user_id="abc-123", days=7)
+    # → {"inserted": 5, "updated": 0, "skipped": 2, "errors": 0}
+"""
+
+import argparse
+import os
+import sys
+from datetime import date, datetime, timedelta
+from typing import Optional
+
+from sleephq import AuthenticatedClient
+from sleephq.api.machines import get_v1_machines_machine_id_machine_dates
+from sleephq.api.teams import get_v1_teams
+from sleephq.api.machines import get_v1_teams_team_id_machines
+
+from db import get_conn, session_exists, upsert_session
+
+
+# ---------------------------------------------------------------------------
+# Client / authentication
+# ---------------------------------------------------------------------------
+
+def create_sleephq_client(
+    client_id: Optional[str] = None,
+    client_secret: Optional[str] = None,
+) -> AuthenticatedClient:
+    """Authenticate with SleepHQ and return an authenticated client."""
+    cid = client_id or os.environ["SLEEPHQ_CLIENT_ID"]
+    csecret = client_secret or os.environ["SLEEPHQ_CLIENT_SECRET"]
+    return AuthenticatedClient(client_id=cid, client_secret=csecret)
+
+
+# ---------------------------------------------------------------------------
+# ID resolution helpers
+# ---------------------------------------------------------------------------
+
+def resolve_team_id(client: AuthenticatedClient) -> int:
+    """Return the team ID from env or auto-resolve via the API."""
+    env_val = os.environ.get("SLEEPHQ_TEAM_ID")
+    if env_val:
+        return int(env_val)
+
+    resp = get_v1_teams.sync_detailed(client=client)
+    if resp.status_code != 200 or not resp.parsed:
+        raise RuntimeError(f"Failed to list teams: HTTP {resp.status_code}")
+
+    teams = resp.parsed
+    if not teams:
+        raise RuntimeError("No teams found on this SleepHQ account")
+
+    # Use first team; most users have exactly one
+    team = teams[0]
+    return _attr(team, "id", "team_id")
+
+
+def resolve_machine_id(client: AuthenticatedClient, team_id: int) -> int:
+    """Return the machine ID from env or auto-resolve via the API."""
+    env_val = os.environ.get("SLEEPHQ_MACHINE_ID")
+    if env_val:
+        return int(env_val)
+
+    resp = get_v1_teams_team_id_machines.sync_detailed(
+        team_id=team_id, client=client
+    )
+    if resp.status_code != 200 or not resp.parsed:
+        raise RuntimeError(f"Failed to list machines: HTTP {resp.status_code}")
+
+    machines = resp.parsed
+    if not machines:
+        raise RuntimeError("No machines found for this team")
+
+    machine = machines[0]
+    return _attr(machine, "id", "machine_id")
+
+
+# ---------------------------------------------------------------------------
+# Data fetching
+# ---------------------------------------------------------------------------
+
+def fetch_machine_dates(
+    client: AuthenticatedClient,
+    machine_id: int,
+    from_date: Optional[date] = None,
+    to_date: Optional[date] = None,
+    days: int = 30,
+) -> list:
+    """
+    Fetch paginated machine_dates records from the SleepHQ API.
+
+    If neither from_date nor to_date is given, fetches the last `days` days.
+    Returns a flat list of machine_date objects.
+    """
+    if from_date is None:
+        to_date = to_date or date.today()
+        from_date = to_date - timedelta(days=days)
+
+    to_date = to_date or date.today()
+
+    all_records = []
+    page = 1
+
+    while True:
+        resp = get_v1_machines_machine_id_machine_dates.sync_detailed(
+            machine_id=machine_id,
+            client=client,
+            start_date=from_date.isoformat(),
+            end_date=to_date.isoformat(),
+            page=page,
+        )
+
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"machine_dates fetch failed: HTTP {resp.status_code}"
+            )
+
+        parsed = resp.parsed
+        if parsed is None:
+            break
+
+        # Normalise: response may be a list directly or wrapped in .data
+        records = _attr_safe(parsed, "data") or (parsed if isinstance(parsed, list) else [])
+        if not records:
+            break
+
+        all_records.extend(records)
+
+        # Pagination: stop when we receive fewer records than a full page
+        # or when meta.next_page is None
+        meta = _attr_safe(parsed, "meta")
+        if meta:
+            next_page = _attr_safe(meta, "next_page")
+            if not next_page:
+                break
+        elif len(records) < 25:
+            # No meta; fall back to heuristic
+            break
+
+        page += 1
+
+    return all_records
+
+
+# ---------------------------------------------------------------------------
+# Field mapping
+# ---------------------------------------------------------------------------
+
+def _attr(obj, *names, default=None):
+    """Return the first attribute in `names` that exists and is not None."""
+    for name in names:
+        val = getattr(obj, name, None)
+        if val is not None:
+            return val
+        # Some generated clients nest data under .attributes
+        attrs = getattr(obj, "attributes", None)
+        if attrs is not None:
+            val = getattr(attrs, name, None)
+            if val is not None:
+                return val
+    return default
+
+
+def _attr_safe(obj, name, default=None):
+    """Return obj.name if it exists, else default."""
+    return getattr(obj, name, default)
+
+
+def map_machine_date_to_session(record, user_id: str) -> dict:
+    """
+    Map a SleepHQ machine_date record to the dict expected by
+    db.upsert_session().  Field names are tried in priority order to
+    handle minor schema variations across sleephq-client versions.
+    """
+    record_id = _attr(record, "id", "record_id")
+    session_id = f"sleephq-{record_id}"
+
+    # Date — ISO string ("2025-03-15") or a date object
+    raw_date = _attr(record, "date", "session_date", "calendar_date")
+    if isinstance(raw_date, str):
+        folder_date = date.fromisoformat(raw_date)
+    elif isinstance(raw_date, date):
+        folder_date = raw_date
+    else:
+        folder_date = None
+
+    # Start datetime
+    raw_start = _attr(record, "start_time", "session_start", "starts_at")
+    if isinstance(raw_start, str):
+        start_datetime = datetime.fromisoformat(raw_start.replace("Z", "+00:00"))
+    elif isinstance(raw_start, datetime):
+        start_datetime = raw_start
+    else:
+        start_datetime = (
+            datetime(folder_date.year, folder_date.month, folder_date.day)
+            if folder_date
+            else None
+        )
+
+    # Duration — may be in seconds or minutes depending on API version
+    duration_raw = _attr(record, "duration", "session_duration", "total_duration")
+    duration_seconds = None
+    if duration_raw is not None:
+        duration_seconds = int(duration_raw)
+        # Heuristic: durations > 86400 are probably in ms; < 600 probably in minutes
+        if duration_seconds > 86400:
+            duration_seconds //= 1000
+        elif duration_seconds < 600:
+            duration_seconds *= 60
+
+    # AHI
+    ahi = _attr(record, "ahi", "apnea_hypopnea_index")
+    try:
+        ahi = round(float(ahi), 2) if ahi is not None else None
+    except (TypeError, ValueError):
+        ahi = None
+
+    # Event counts
+    def _int(val):
+        try:
+            return int(val) if val is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    ca  = _int(_attr(record, "central_apnea_count", "central_apneas",  "ca_count"))
+    oa  = _int(_attr(record, "obstructive_apnea_count", "obstructive_apneas", "oa_count"))
+    h   = _int(_attr(record, "hypopnea_count", "hypopneas"))
+    a   = _int(_attr(record, "apnea_count",    "apneas"))
+    ar  = _int(_attr(record, "arousal_count",  "arousals"))
+
+    total_ahi_events = _int(_attr(record, "total_ahi_events"))
+    if total_ahi_events is None:
+        counts = [ca, oa, h, a]
+        if any(c is not None for c in counts):
+            total_ahi_events = sum(c for c in counts if c is not None)
+
+    # Pressures / ventilation
+    def _float(val, ndigits=4):
+        try:
+            return round(float(val), ndigits) if val is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    avg_pressure = _float(_attr(record, "avg_pressure",  "average_pressure",   "median_pressure"))
+    p95_pressure = _float(_attr(record, "p95_pressure",  "pressure_95",        "p95"))
+    avg_leak     = _float(_attr(record, "avg_leak",      "average_leak",       "leak"))
+    avg_resp_rate = _float(_attr(record, "avg_resp_rate", "average_resp_rate", "resp_rate"))
+    avg_tidal_vol = _float(_attr(record, "avg_tidal_vol", "tidal_volume",      "tidal_vol"))
+    avg_min_vent  = _float(_attr(record, "avg_min_vent",  "minute_ventilation", "min_vent"))
+    avg_snore     = _float(_attr(record, "avg_snore",     "snore_index",        "snore"))
+    avg_flow_lim  = _float(_attr(record, "avg_flow_lim",  "flow_limitation",   "flow_lim"))
+
+    # Device serial
+    device_serial = _attr(record, "device_serial", "serial_number", "device_id")
+    if device_serial is not None:
+        device_serial = str(device_serial)
+
+    return {
+        "session_id":              session_id,
+        "folder_date":             folder_date,
+        "block_index":             0,
+        "start_datetime":          start_datetime,
+        "pld_start_datetime":      start_datetime,
+        "duration_seconds":        duration_seconds,
+        "device_serial":           device_serial,
+        "ahi":                     ahi,
+        "central_apnea_count":     ca,
+        "obstructive_apnea_count": oa,
+        "hypopnea_count":          h,
+        "apnea_count":             a,
+        "arousal_count":           ar,
+        "total_ahi_events":        total_ahi_events,
+        "avg_pressure":            avg_pressure,
+        "p95_pressure":            p95_pressure,
+        "avg_leak":                avg_leak,
+        "avg_resp_rate":           avg_resp_rate,
+        "avg_tidal_vol":           avg_tidal_vol,
+        "avg_min_vent":            avg_min_vent,
+        "avg_snore":               avg_snore,
+        "avg_flow_lim":            avg_flow_lim,
+        "has_spo2":                False,
+        "user_id":                 user_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+def persist_sessions(
+    conn,
+    records: list,
+    user_id: str,
+    skip_existing: bool = True,
+    dry_run: bool = False,
+) -> dict:
+    """
+    Upsert mapped session records into Postgres.
+
+    Returns a stats dict: {"inserted": N, "updated": N, "skipped": N, "errors": N}
+    """
+    stats = {"inserted": 0, "updated": 0, "skipped": 0, "errors": 0}
+
+    for record in records:
+        try:
+            session_data = map_machine_date_to_session(record, user_id)
+            sid = session_data["session_id"]
+
+            exists = session_exists(conn, user_id, sid)
+
+            if exists and skip_existing:
+                print(f"  SKIP {sid}: already imported")
+                stats["skipped"] += 1
+                continue
+
+            if dry_run:
+                action = "UPDATE (dry)" if exists else "INSERT (dry)"
+                print(f"  {action} {sid}")
+                if exists:
+                    stats["updated"] += 1
+                else:
+                    stats["inserted"] += 1
+                continue
+
+            upsert_session(conn, session_data)
+            conn.commit()
+
+            action = "UPDATE" if exists else "INSERT"
+            print(f"  {action} {sid}")
+            if exists:
+                stats["updated"] += 1
+            else:
+                stats["inserted"] += 1
+
+        except Exception as e:
+            conn.rollback()
+            record_id = _attr_safe(record, "id") or "?"
+            print(f"  ERROR sleephq-{record_id}: {e}")
+            stats["errors"] += 1
+
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+
+def run_sleephq_import(
+    user_id: str,
+    days: int = 30,
+    from_date: Optional[date] = None,
+    to_date: Optional[date] = None,
+    skip_existing: bool = True,
+    dry_run: bool = False,
+    client_id: Optional[str] = None,
+    client_secret: Optional[str] = None,
+    team_id: Optional[int] = None,
+    machine_id: Optional[int] = None,
+) -> dict:
+    """
+    Full SleepHQ → Postgres pipeline.
+
+    Returns stats dict: {"inserted": N, "updated": N, "skipped": N, "errors": N}
+
+    Credentials are read from the environment unless explicitly passed.
+    Callers that manage per-user creds (e.g. the server-path importer)
+    should inject them via client_id / client_secret rather than
+    mutating os.environ directly.
+    """
+    # Temporarily override env vars if explicit creds provided
+    _orig = {}
+    if client_id:
+        _orig["SLEEPHQ_CLIENT_ID"] = os.environ.get("SLEEPHQ_CLIENT_ID")
+        os.environ["SLEEPHQ_CLIENT_ID"] = client_id
+    if client_secret:
+        _orig["SLEEPHQ_CLIENT_SECRET"] = os.environ.get("SLEEPHQ_CLIENT_SECRET")
+        os.environ["SLEEPHQ_CLIENT_SECRET"] = client_secret
+    if team_id:
+        _orig["SLEEPHQ_TEAM_ID"] = os.environ.get("SLEEPHQ_TEAM_ID")
+        os.environ["SLEEPHQ_TEAM_ID"] = str(team_id)
+    if machine_id:
+        _orig["SLEEPHQ_MACHINE_ID"] = os.environ.get("SLEEPHQ_MACHINE_ID")
+        os.environ["SLEEPHQ_MACHINE_ID"] = str(machine_id)
+
+    try:
+        client = create_sleephq_client()
+        resolved_team_id = resolve_team_id(client)
+        resolved_machine_id = resolve_machine_id(client, resolved_team_id)
+
+        print(
+            f"SleepHQ import: team={resolved_team_id} "
+            f"machine={resolved_machine_id} user={user_id}"
+        )
+
+        records = fetch_machine_dates(
+            client,
+            machine_id=resolved_machine_id,
+            from_date=from_date,
+            to_date=to_date,
+            days=days,
+        )
+        print(f"  Fetched {len(records)} record(s) from SleepHQ")
+
+        if not records:
+            return {"inserted": 0, "updated": 0, "skipped": 0, "errors": 0}
+
+        conn = get_conn()
+        try:
+            stats = persist_sessions(
+                conn,
+                records,
+                user_id,
+                skip_existing=skip_existing,
+                dry_run=dry_run,
+            )
+        finally:
+            conn.close()
+
+    finally:
+        # Restore original environment
+        for key, original_val in _orig.items():
+            if original_val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = original_val
+
+    print(
+        f"Done. inserted={stats['inserted']} updated={stats['updated']} "
+        f"skipped={stats['skipped']} errors={stats['errors']}"
+    )
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Import SleepHQ session history into the sleeplab database"
+    )
+    parser.add_argument(
+        "--user-id", required=True, dest="user_id",
+        help="User UUID to associate sessions with"
+    )
+
+    date_group = parser.add_mutually_exclusive_group()
+    date_group.add_argument(
+        "--days", type=int, default=30,
+        help="Number of past days to fetch (default: 30)"
+    )
+    date_group.add_argument(
+        "--from", dest="from_date", metavar="YYYY-MM-DD",
+        help="Start of date range (inclusive)"
+    )
+
+    parser.add_argument(
+        "--to", dest="to_date", metavar="YYYY-MM-DD",
+        help="End of date range (inclusive, default: today)"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Fetch and map records but do not write to the database"
+    )
+    parser.add_argument(
+        "--force", action="store_true",
+        help="Overwrite existing sessions instead of skipping them"
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+
+    from_date = date.fromisoformat(args.from_date) if args.from_date else None
+    to_date   = date.fromisoformat(args.to_date)   if args.to_date   else None
+
+    run_sleephq_import(
+        user_id=args.user_id,
+        days=args.days,
+        from_date=from_date,
+        to_date=to_date,
+        skip_existing=not args.force,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/importer/sleephq_import.py
+++ b/importer/sleephq_import.py
@@ -35,16 +35,89 @@ Programmatic usage:
 
 import argparse
 import os
+import random
 import sys
+import time
 from datetime import date, datetime, timedelta
 from typing import Optional
 
+import httpx
+
 from sleephq import AuthenticatedClient
-from sleephq.api.machines import get_v1_machines_machine_id_machine_dates
+from sleephq.auth import create_client as _sleephq_create_client
+from sleephq.api.machine_dates import get_v1_machines_machine_id_machine_dates
 from sleephq.api.teams import get_v1_teams
 from sleephq.api.machines import get_v1_teams_team_id_machines
 
 from db import get_conn, session_exists, upsert_session
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit / retry helpers
+# ---------------------------------------------------------------------------
+
+#: HTTP status codes that warrant a retry with backoff.
+_RETRY_STATUSES = {429, 500, 502, 503, 504}
+
+#: Maximum number of attempts before giving up (1 original + N-1 retries).
+_MAX_ATTEMPTS = 8
+
+#: Base delay in seconds for exponential backoff.
+_BASE_DELAY = 2.0
+
+#: Hard cap on a single wait interval.
+_MAX_DELAY = 300.0  # 5 minutes
+
+#: Polite pause between successive paginated API requests.
+_PAGE_DELAY = 1.5  # seconds
+
+
+def _backoff_delay(attempt: int, retry_after_header: Optional[str] = None) -> float:
+    """
+    Return how many seconds to wait before the next attempt.
+
+    Prefers the ``Retry-After`` header value when present.  Otherwise uses
+    full-jitter exponential backoff:  random(0, min(base * 2^attempt, cap)).
+    """
+    if retry_after_header:
+        try:
+            return max(1.0, float(retry_after_header))
+        except (TypeError, ValueError):
+            pass
+    cap = min(_BASE_DELAY * (2 ** attempt), _MAX_DELAY)
+    return random.uniform(0, cap)
+
+
+def _api_call_with_retry(fn, *args, label: str = "API call", **kwargs):
+    """
+    Call ``fn(*args, **kwargs)`` and retry on transient / rate-limit errors.
+
+    ``fn`` must return an httpx-style response object with a ``status_code``
+    attribute and a ``headers`` mapping (i.e. the ``Response`` type returned
+    by sleephq-client ``sync_detailed`` functions).
+
+    Raises ``RuntimeError`` if all attempts are exhausted.
+    """
+    last_resp = None
+    for attempt in range(_MAX_ATTEMPTS):
+        last_resp = fn(*args, **kwargs)
+        if last_resp.status_code not in _RETRY_STATUSES:
+            return last_resp
+
+        retry_after = None
+        if hasattr(last_resp, "headers") and last_resp.headers:
+            retry_after = last_resp.headers.get("Retry-After")
+
+        wait = _backoff_delay(attempt, retry_after)
+        print(
+            f"  [{label}] HTTP {last_resp.status_code} — "
+            f"waiting {wait:.1f}s before retry {attempt + 1}/{_MAX_ATTEMPTS - 1}…",
+            file=sys.stderr,
+        )
+        time.sleep(wait)
+
+    # Return the last response; caller decides whether to raise or continue.
+    return last_resp
 
 
 # ---------------------------------------------------------------------------
@@ -55,10 +128,35 @@ def create_sleephq_client(
     client_id: Optional[str] = None,
     client_secret: Optional[str] = None,
 ) -> AuthenticatedClient:
-    """Authenticate with SleepHQ and return an authenticated client."""
+    """
+    Authenticate with SleepHQ via OAuth2 and return an authenticated client.
+
+    Retries up to ``_MAX_ATTEMPTS`` times on HTTP 429 (rate limit) with
+    exponential back-off, honouring the ``Retry-After`` header when present.
+    """
     cid = client_id or os.environ["SLEEPHQ_CLIENT_ID"]
     csecret = client_secret or os.environ["SLEEPHQ_CLIENT_SECRET"]
-    return AuthenticatedClient(client_id=cid, client_secret=csecret)
+
+    last_exc: Optional[Exception] = None
+    for attempt in range(_MAX_ATTEMPTS):
+        try:
+            return _sleephq_create_client(client_id=cid, client_secret=csecret)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code not in _RETRY_STATUSES:
+                raise
+            retry_after = exc.response.headers.get("Retry-After")
+            wait = _backoff_delay(attempt, retry_after)
+            print(
+                f"  [auth] HTTP {exc.response.status_code} — "
+                f"waiting {wait:.1f}s before retry {attempt + 1}/{_MAX_ATTEMPTS - 1}…",
+                file=sys.stderr,
+            )
+            time.sleep(wait)
+            last_exc = exc
+
+    raise RuntimeError(
+        f"SleepHQ authentication failed after {_MAX_ATTEMPTS} attempts"
+    ) from last_exc
 
 
 # ---------------------------------------------------------------------------
@@ -71,17 +169,17 @@ def resolve_team_id(client: AuthenticatedClient) -> int:
     if env_val:
         return int(env_val)
 
-    resp = get_v1_teams.sync_detailed(client=client)
+    resp = _api_call_with_retry(
+        get_v1_teams.sync_detailed, client=client, label="GET /teams"
+    )
     if resp.status_code != 200 or not resp.parsed:
         raise RuntimeError(f"Failed to list teams: HTTP {resp.status_code}")
 
-    teams = resp.parsed
-    if not teams:
+    items = getattr(resp.parsed, "data", None) or []
+    if not items:
         raise RuntimeError("No teams found on this SleepHQ account")
 
-    # Use first team; most users have exactly one
-    team = teams[0]
-    return _attr(team, "id", "team_id")
+    return int(items[0].id)
 
 
 def resolve_machine_id(client: AuthenticatedClient, team_id: int) -> int:
@@ -90,18 +188,20 @@ def resolve_machine_id(client: AuthenticatedClient, team_id: int) -> int:
     if env_val:
         return int(env_val)
 
-    resp = get_v1_teams_team_id_machines.sync_detailed(
-        team_id=team_id, client=client
+    resp = _api_call_with_retry(
+        get_v1_teams_team_id_machines.sync_detailed,
+        team_id=team_id,
+        client=client,
+        label=f"GET /teams/{team_id}/machines",
     )
     if resp.status_code != 200 or not resp.parsed:
         raise RuntimeError(f"Failed to list machines: HTTP {resp.status_code}")
 
-    machines = resp.parsed
-    if not machines:
+    items = getattr(resp.parsed, "data", None) or []
+    if not items:
         raise RuntimeError("No machines found for this team")
 
-    machine = machines[0]
-    return _attr(machine, "id", "machine_id")
+    return int(items[0].id)
 
 
 # ---------------------------------------------------------------------------
@@ -116,54 +216,101 @@ def fetch_machine_dates(
     days: int = 30,
 ) -> list:
     """
-    Fetch paginated machine_dates records from the SleepHQ API.
+    Fetch machine_dates records from the SleepHQ API, filtered to a date range.
 
-    If neither from_date nor to_date is given, fetches the last `days` days.
-    Returns a flat list of machine_date objects.
+    The API returns records sorted DESC (newest first) with no server-side date
+    filter.  We paginate through all pages, applying client-side date filtering,
+    and stop as soon as we reach a record older than ``from_date``.
+
+    Each page request is retried automatically on 429 / transient 5xx with
+    exponential back-off (see ``_api_call_with_retry``).  A short polite pause
+    (``_PAGE_DELAY``) is inserted between successive pages so we don't saturate
+    the API when importing long histories.
+
+    If neither from_date nor to_date is given, fetches the last ``days`` days.
+    Returns a flat list of machine_date items (JSON:API data items).
     """
+    from sleephq.types import Unset
+
     if from_date is None:
         to_date = to_date or date.today()
         from_date = to_date - timedelta(days=days)
 
     to_date = to_date or date.today()
 
-    all_records = []
+    span_days = (to_date - from_date).days
+    print(
+        f"  Fetching machine_dates for machine {machine_id}: "
+        f"{from_date} → {to_date} ({span_days} days)"
+    )
+
+    all_records: list = []
     page = 1
 
     while True:
-        resp = get_v1_machines_machine_id_machine_dates.sync_detailed(
+        if page > 1:
+            time.sleep(_PAGE_DELAY)
+
+        resp = _api_call_with_retry(
+            get_v1_machines_machine_id_machine_dates.sync_detailed,
             machine_id=machine_id,
             client=client,
-            start_date=from_date.isoformat(),
-            end_date=to_date.isoformat(),
             page=page,
+            label=f"GET machine_dates page {page}",
         )
 
         if resp.status_code != 200:
             raise RuntimeError(
-                f"machine_dates fetch failed: HTTP {resp.status_code}"
+                f"machine_dates fetch failed on page {page}: HTTP {resp.status_code}"
             )
 
         parsed = resp.parsed
         if parsed is None:
             break
 
-        # Normalise: response may be a list directly or wrapped in .data
-        records = _attr_safe(parsed, "data") or (parsed if isinstance(parsed, list) else [])
-        if not records:
+        records = getattr(parsed, "data", None)
+        if not records or isinstance(records, Unset):
             break
 
-        all_records.extend(records)
+        page_kept = 0
+        reached_start = False
 
-        # Pagination: stop when we receive fewer records than a full page
-        # or when meta.next_page is None
-        meta = _attr_safe(parsed, "meta")
-        if meta:
-            next_page = _attr_safe(meta, "next_page")
-            if not next_page:
+        for rec in records:
+            rec_attrs = getattr(rec, "attributes", None)
+            rec_date  = getattr(rec_attrs, "date", None) if rec_attrs else None
+            if isinstance(rec_date, Unset):
+                rec_date = None
+
+            if isinstance(rec_date, str):
+                try:
+                    rec_date = date.fromisoformat(rec_date)
+                except ValueError:
+                    rec_date = None
+
+            # No date on record — include it and keep going
+            if rec_date is None:
+                all_records.append(rec)
+                page_kept += 1
+                continue
+
+            # Sorted DESC: skip anything newer than our window
+            if rec_date > to_date:
+                continue
+
+            # Past the start of our window — no need to fetch further pages
+            if rec_date < from_date:
+                reached_start = True
                 break
-        elif len(records) < 25:
-            # No meta; fall back to heuristic
+
+            all_records.append(rec)
+            page_kept += 1
+
+        print(
+            f"    page {page}: {len(records)} records returned, "
+            f"{page_kept} in window, {len(all_records)} total so far"
+        )
+
+        if reached_start or len(records) < 100:
             break
 
         page += 1
@@ -195,17 +342,47 @@ def _attr_safe(obj, name, default=None):
     return getattr(obj, name, default)
 
 
+def _sub(summary_obj, *keys, default=None):
+    """
+    Read a value from a JSON:API summary sub-object (ahi_summary,
+    pressure_summary, etc.).  These are schema-less bags stored in
+    .additional_properties, so dict-style access is required.
+    """
+    if summary_obj is None:
+        return default
+    from sleephq.types import Unset
+    if isinstance(summary_obj, Unset):
+        return default
+    props = getattr(summary_obj, "additional_properties", {}) or {}
+    for key in keys:
+        val = props.get(key)
+        if val is not None:
+            return val
+    return default
+
+
 def map_machine_date_to_session(record, user_id: str) -> dict:
     """
-    Map a SleepHQ machine_date record to the dict expected by
-    db.upsert_session().  Field names are tried in priority order to
-    handle minor schema variations across sleephq-client versions.
+    Map a SleepHQ machine_date record (JSON:API format) to the dict
+    expected by db.upsert_session().
+
+    The record has:
+      record.id                  — string record ID
+      record.attributes.date     — date object
+      record.attributes.usage    — int (seconds of usage)
+      record.attributes.*_summary — dict-bag via .additional_properties
     """
-    record_id = _attr(record, "id", "record_id")
+    from sleephq.types import Unset
+
+    record_id = record.id if not isinstance(getattr(record, "id", None), Unset) else None
     session_id = f"sleephq-{record_id}"
 
-    # Date — ISO string ("2025-03-15") or a date object
-    raw_date = _attr(record, "date", "session_date", "calendar_date")
+    attrs = record.attributes if not isinstance(getattr(record, "attributes", None), Unset) else None
+
+    # ── Date ────────────────────────────────────────────────────────────────
+    raw_date = getattr(attrs, "date", None) if attrs else None
+    if isinstance(raw_date, Unset):
+        raw_date = None
     if isinstance(raw_date, str):
         folder_date = date.fromisoformat(raw_date)
     elif isinstance(raw_date, date):
@@ -213,76 +390,104 @@ def map_machine_date_to_session(record, user_id: str) -> dict:
     else:
         folder_date = None
 
-    # Start datetime
-    raw_start = _attr(record, "start_time", "session_start", "starts_at")
-    if isinstance(raw_start, str):
-        start_datetime = datetime.fromisoformat(raw_start.replace("Z", "+00:00"))
-    elif isinstance(raw_start, datetime):
-        start_datetime = raw_start
-    else:
-        start_datetime = (
-            datetime(folder_date.year, folder_date.month, folder_date.day)
-            if folder_date
-            else None
-        )
+    # ── Start datetime ───────────────────────────────────────────────────────
+    # SleepHQ doesn't expose a start_time on machine_dates; use midnight of
+    # the session date as a reasonable default.
+    start_datetime = (
+        datetime(folder_date.year, folder_date.month, folder_date.day)
+        if folder_date
+        else None
+    )
 
-    # Duration — may be in seconds or minutes depending on API version
-    duration_raw = _attr(record, "duration", "session_duration", "total_duration")
+    # ── Duration ─────────────────────────────────────────────────────────────
+    # attributes.usage is confirmed to be in seconds (e.g. 27960 = ~7.8 h).
+    usage_raw = getattr(attrs, "usage", None) if attrs else None
     duration_seconds = None
-    if duration_raw is not None:
-        duration_seconds = int(duration_raw)
-        # Heuristic: durations > 86400 are probably in ms; < 600 probably in minutes
-        if duration_seconds > 86400:
-            duration_seconds //= 1000
-        elif duration_seconds < 600:
-            duration_seconds *= 60
-
-    # AHI
-    ahi = _attr(record, "ahi", "apnea_hypopnea_index")
-    try:
-        ahi = round(float(ahi), 2) if ahi is not None else None
-    except (TypeError, ValueError):
-        ahi = None
-
-    # Event counts
-    def _int(val):
+    if usage_raw is not None and not isinstance(usage_raw, Unset):
         try:
-            return int(val) if val is not None else None
+            duration_seconds = int(usage_raw)
         except (TypeError, ValueError):
-            return None
+            pass
 
-    ca  = _int(_attr(record, "central_apnea_count", "central_apneas",  "ca_count"))
-    oa  = _int(_attr(record, "obstructive_apnea_count", "obstructive_apneas", "oa_count"))
-    h   = _int(_attr(record, "hypopnea_count", "hypopneas"))
-    a   = _int(_attr(record, "apnea_count",    "apneas"))
-    ar  = _int(_attr(record, "arousal_count",  "arousals"))
-
-    total_ahi_events = _int(_attr(record, "total_ahi_events"))
-    if total_ahi_events is None:
-        counts = [ca, oa, h, a]
-        if any(c is not None for c in counts):
-            total_ahi_events = sum(c for c in counts if c is not None)
-
-    # Pressures / ventilation
     def _float(val, ndigits=4):
         try:
             return round(float(val), ndigits) if val is not None else None
         except (TypeError, ValueError):
             return None
 
-    avg_pressure = _float(_attr(record, "avg_pressure",  "average_pressure",   "median_pressure"))
-    p95_pressure = _float(_attr(record, "p95_pressure",  "pressure_95",        "p95"))
-    avg_leak     = _float(_attr(record, "avg_leak",      "average_leak",       "leak"))
-    avg_resp_rate = _float(_attr(record, "avg_resp_rate", "average_resp_rate", "resp_rate"))
-    avg_tidal_vol = _float(_attr(record, "avg_tidal_vol", "tidal_volume",      "tidal_vol"))
-    avg_min_vent  = _float(_attr(record, "avg_min_vent",  "minute_ventilation", "min_vent"))
-    avg_snore     = _float(_attr(record, "avg_snore",     "snore_index",        "snore"))
-    avg_flow_lim  = _float(_attr(record, "avg_flow_lim",  "flow_limitation",   "flow_lim"))
+    def _int(val):
+        try:
+            return int(round(float(val))) if val is not None else None
+        except (TypeError, ValueError):
+            return None
 
-    # Device serial
-    device_serial = _attr(record, "device_serial", "serial_number", "device_id")
-    if device_serial is not None:
-        device_serial = str(device_serial)
+    # ── AHI summary ──────────────────────────────────────────────────────────
+    # Keys confirmed from live API: total, hypopnea, all_apnea, clear_airway,
+    # obstructive_apnea, unidentified_apnea.
+    # Values are per-hour indices (not raw counts).  We derive counts by
+    # multiplying the index by session duration in hours.
+    ahi_s = getattr(attrs, "ahi_summary", None) if attrs else None
+
+    ahi = _float(_sub(ahi_s, "total"), 2)
+
+    duration_hours = (duration_seconds / 3600.0) if duration_seconds else None
+
+    def _index_to_count(index_val):
+        """Convert a per-hour event index to an integer count."""
+        if index_val is None or duration_hours is None:
+            return None
+        return _int(float(index_val) * duration_hours)
+
+    ca = _index_to_count(_sub(ahi_s, "clear_airway"))
+    oa = _index_to_count(_sub(ahi_s, "obstructive_apnea"))
+    h  = _index_to_count(_sub(ahi_s, "hypopnea"))
+    # all_apnea covers obstructive + unidentified; store as the generic apnea count
+    a  = _index_to_count(_sub(ahi_s, "all_apnea"))
+    ar = None  # not present in machine_dates
+
+    total_ahi_events = _index_to_count(_sub(ahi_s, "total"))
+    # If we got a total index but no individual counts, total is still useful
+    if total_ahi_events is None and ahi is not None and duration_hours is not None:
+        total_ahi_events = _int(ahi * duration_hours)
+
+    # ── Pressure summary ─────────────────────────────────────────────────────
+    # Confirmed keys: av (mean), med (median), upper (95th percentile), max, min
+    pres_s = getattr(attrs, "pressure_summary", None) if attrs else None
+    avg_pressure = _float(_sub(pres_s, "av"))
+    p95_pressure = _float(_sub(pres_s, "upper"))
+
+    # ── Leak rate summary ────────────────────────────────────────────────────
+    # Confirmed keys: av, med, upper, max, min, score
+    leak_s = getattr(attrs, "leak_rate_summary", None) if attrs else None
+    avg_leak = _float(_sub(leak_s, "av"))
+
+    # ── Respiratory rate summary ─────────────────────────────────────────────
+    # Confirmed keys: av, med, upper, max, min
+    rr_s = getattr(attrs, "resp_rate_summary", None) if attrs else None
+    avg_resp_rate = _float(_sub(rr_s, "av"))
+
+    # ── Flow limitation summary ──────────────────────────────────────────────
+    # Confirmed keys: av, med, upper, max, min
+    fl_s = getattr(attrs, "flow_limit_summary", None) if attrs else None
+    avg_flow_lim = _float(_sub(fl_s, "av"))
+
+    # ── SpO2 / pulse summary ─────────────────────────────────────────────────
+    # Returns empty dict for most machines; has_spo2 = True only if non-empty
+    spo2_s = getattr(attrs, "spo2_summary", None) if attrs else None
+    has_spo2 = bool(
+        spo2_s is not None
+        and not isinstance(spo2_s, Unset)
+        and getattr(spo2_s, "additional_properties", {})
+    )
+
+    # Fields not present in machine_dates (no per-session waveform summaries)
+    avg_tidal_vol = None
+    avg_min_vent  = None
+    avg_snore     = None
+
+    # ── Device serial ────────────────────────────────────────────────────────
+    # Not present on machine_dates; would need to join against the machine record
+    device_serial = None
 
     return {
         "session_id":              session_id,
@@ -307,7 +512,7 @@ def map_machine_date_to_session(record, user_id: str) -> dict:
         "avg_min_vent":            avg_min_vent,
         "avg_snore":               avg_snore,
         "avg_flow_lim":            avg_flow_lim,
-        "has_spo2":                False,
+        "has_spo2":                has_spo2,
         "user_id":                 user_id,
     }
 

--- a/importer/test_sleephq_fetch.py
+++ b/importer/test_sleephq_fetch.py
@@ -1,0 +1,201 @@
+"""
+Test harness: fetch one month of SleepHQ history for one or more teams and
+print the rows as they would be mapped into the sessions table.
+
+No database writes are performed.
+
+Usage:
+    cd importer
+    SLEEPHQ_CLIENT_ID=... SLEEPHQ_CLIENT_SECRET=... SLEEPHQ_TEAM_IDS=43940,104558 \\
+        python test_sleephq_fetch.py
+
+    # Single team — SLEEPHQ_TEAM_ID also accepted
+    SLEEPHQ_CLIENT_ID=... SLEEPHQ_CLIENT_SECRET=... SLEEPHQ_TEAM_ID=43940 \\
+        python test_sleephq_fetch.py
+
+Or set the variables in .env (db.py loads it automatically) and just run:
+    python test_sleephq_fetch.py
+"""
+
+import os
+import sys
+from datetime import date, timedelta
+
+
+def _load_users_from_env() -> list[dict]:
+    """
+    Build a per-team user list from environment variables.
+
+    Reads SLEEPHQ_TEAM_IDS (comma-separated) or falls back to SLEEPHQ_TEAM_ID.
+    Each team gets a generic placeholder user_id of the form "test-team-<id>".
+    """
+    raw = os.environ.get("SLEEPHQ_TEAM_IDS") or os.environ.get("SLEEPHQ_TEAM_ID", "")
+    team_ids = [t.strip() for t in raw.split(",") if t.strip()]
+    if not team_ids:
+        return []
+    return [
+        {"label": f"team-{tid}", "team_id": int(tid), "user_id": f"test-team-{tid}"}
+        for tid in team_ids
+    ]
+
+
+DAYS = 30  # how many days of history to pull
+
+# Columns to display in the table (subset of the full sessions schema).
+# Adjust this list if you want to see more or fewer fields.
+DISPLAY_COLS = [
+    "session_id",
+    "folder_date",
+    "start_datetime",
+    "duration_seconds",
+    "ahi",
+    "central_apnea_count",
+    "obstructive_apnea_count",
+    "hypopnea_count",
+    "total_ahi_events",
+    "avg_pressure",
+    "p95_pressure",
+    "avg_leak",
+    "avg_resp_rate",
+    "device_serial",
+]
+
+# ── Imports ──────────────────────────────────────────────────────────────────
+
+# db.py loads .env; import it first so env vars are available
+import db  # noqa: F401 (side-effect: loads .env)
+
+from sleephq_import import (
+    create_sleephq_client,
+    fetch_machine_dates,
+    map_machine_date_to_session,
+    resolve_machine_id,
+)
+
+
+# ── Formatting helpers ───────────────────────────────────────────────────────
+
+def _fmt(val) -> str:
+    if val is None:
+        return "—"
+    if isinstance(val, float):
+        return f"{val:.2f}"
+    return str(val)
+
+
+def print_table(rows: list[dict], cols: list[str], title: str) -> None:
+    """Print a fixed-width table to stdout."""
+    print(f"\n{'=' * 100}")
+    print(f"  {title}  ({len(rows)} row(s))")
+    print(f"{'=' * 100}")
+
+    if not rows:
+        print("  (no records returned)")
+        return
+
+    # Compute column widths: max of header length and data length
+    widths = {c: len(c) for c in cols}
+    for row in rows:
+        for c in cols:
+            widths[c] = max(widths[c], len(_fmt(row.get(c))))
+
+    sep = "  ".join("-" * widths[c] for c in cols)
+    header = "  ".join(c.ljust(widths[c]) for c in cols)
+
+    print(header)
+    print(sep)
+    for row in rows:
+        line = "  ".join(_fmt(row.get(c)).ljust(widths[c]) for c in cols)
+        print(line)
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    client_id     = os.environ.get("SLEEPHQ_CLIENT_ID")
+    client_secret = os.environ.get("SLEEPHQ_CLIENT_SECRET")
+
+    if not client_id or not client_secret:
+        print(
+            "ERROR: SLEEPHQ_CLIENT_ID and SLEEPHQ_CLIENT_SECRET must be set "
+            "in the environment or in .env",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    users = _load_users_from_env()
+    if not users:
+        print(
+            "ERROR: set SLEEPHQ_TEAM_IDS (comma-separated) or SLEEPHQ_TEAM_ID",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    to_date   = date.today()
+    from_date = to_date - timedelta(days=DAYS)
+    print(f"Date range: {from_date} → {to_date}  ({DAYS} days)")
+
+    # Authenticate once — all teams share the same OAuth app credentials.
+    print("\nAuthenticating with SleepHQ…")
+    try:
+        shared_client = create_sleephq_client(client_id, client_secret)
+        print("  OK")
+    except Exception as exc:
+        print(f"  Auth failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    for user in users:
+        label   = user["label"]
+        team_id = user["team_id"]
+        user_id = user["user_id"]
+
+        print(f"\n{'─' * 60}")
+        print(f"Team ID: {team_id}")
+
+        # Temporarily set SLEEPHQ_TEAM_ID so resolve_machine_id() picks it up
+        os.environ["SLEEPHQ_TEAM_ID"] = str(team_id)
+
+        try:
+            client     = shared_client
+            machine_id = resolve_machine_id(client, team_id)
+            print(f"  machine_id resolved → {machine_id}")
+
+            raw_records = fetch_machine_dates(
+                client,
+                machine_id=machine_id,
+                from_date=from_date,
+                to_date=to_date,
+            )
+            print(f"  raw records fetched: {len(raw_records)}")
+
+            # Map every record to the sessions-table dict
+            mapped = [map_machine_date_to_session(r, user_id) for r in raw_records]
+
+            print_table(mapped, DISPLAY_COLS, f"team-{team_id} — sessions table preview")
+
+            # Dump the raw sub-summary dicts from the first record so we can
+            # validate that the field names in map_machine_date_to_session()
+            # match what the API actually returns.
+            if raw_records:
+                first = raw_records[0]
+                attrs = getattr(first, "attributes", None)
+                print(f"\n  [first record id={first.id}]")
+                if attrs:
+                    for sub in ("ahi_summary", "pressure_summary", "leak_rate_summary",
+                                "resp_rate_summary", "flow_limit_summary",
+                                "pulse_rate_summary", "spo2_summary", "movement_summary"):
+                        obj = getattr(attrs, sub, None)
+                        if obj is not None:
+                            props = getattr(obj, "additional_properties", {})
+                            print(f"  {sub}: {props}")
+
+        except Exception as exc:
+            print(f"  FAILED for team-{team_id}: {exc}", file=sys.stderr)
+            import traceback
+            traceback.print_exc()
+        finally:
+            os.environ.pop("SLEEPHQ_TEAM_ID", None)
+
+
+if __name__ == "__main__":
+    main()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "cpap-dashboard",
+  "name": "sleeplab",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cpap-dashboard",
+      "name": "sleeplab",
       "version": "1.0.0",
       "workspaces": [
         "frontend"
@@ -17,12 +17,10 @@
     "frontend": {
       "version": "0.0.0",
       "dependencies": {
-        "@remotion/player": "^4.0.429",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1",
-        "recharts": "^3.7.0",
-        "remotion": "^4.0.429"
+        "recharts": "^3.7.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -1339,19 +1337,6 @@
         "url": "https://opencollective.com/immer"
       }
     },
-    "node_modules/@remotion/player": {
-      "version": "4.0.429",
-      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.429.tgz",
-      "integrity": "sha512-OJM08HvKxwEn8tCS4LphiBLMgTnDcfq+BWwmfkpu1FhbWFxWZPRO5A8RhWokxRgurL4mEwtWLeHYCsZ48JfAvw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "remotion": "4.0.429"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -2143,7 +2128,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2974,7 +2959,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -5153,7 +5138,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -5285,16 +5269,6 @@
       "license": "MIT",
       "peerDependencies": {
         "redux": "^5.0.0"
-      }
-    },
-    "node_modules/remotion": {
-      "version": "4.0.429",
-      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.429.tgz",
-      "integrity": "sha512-SkYwttZ0q/3S28qm/s8eFqmNadTEnZA5U328F7e7kziT48TCFWPyBA9RQ+eUd8g7VmAcv+5AccS8n7cZvB91VA==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/require-directory": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-jose==3.5.0
 passlib==1.7.4
 openai==1.109.1
 python-multipart==0.0.22
+sleephq-client @ git+https://github.com/frohoff/sleephq-client.git


### PR DESCRIPTION

# Summary

  This PR makes the SleepHQ import pipeline fully functional against the real API, adds resilience for long historical imports, and wires up the frontend so users can configure credentials and trigger syncs without  touching the CLI.

  # Backend (importer/sleephq_import.py)

  - Fix API client construction — use sleephq.auth.create_client() (OAuth2 flow) instead of constructing AuthenticatedClient directly with credential kwargs that don't exist
  - Fix module import path — get_v1_machines_machine_id_machine_dates is in sleephq.api.machine_dates, not  sleephq.api.machines
  - Fix JSON:API response navigation — resolve_team_id / resolve_machine_id now read .data[0].id from the  wrapped response instead of treating it as a plain list
  - Fix fetch_machine_dates — the endpoint has no server-side date filter; paginate DESC and stop client-side  when records pass from_date
  - Fix field mapping — confirmed real key names from live API (total, clear_airway, obstructive_apnea, hypopnea, all_apnea, av, upper, …); sub-summary values are per-hour indices so event counts are derived as  index × (duration_seconds / 3600)
  - Rate-limit patience — _api_call_with_retry wraps every sync_detailed call with full-jitter exponential back-off + Retry-After header support (up to 8 attempts, capped at 5 min); OAuth token call gets the same treatment; 1.5 s polite pause between paginated pages so long back-fills work unattended 
 
 #  Test harness
   (importer/test_sleephq_fetch.py, new)

  Dry-run script that fetches one month of data for any number of teams (via SLEEPHQ_TEAM_IDS env var),   prints results in sessions-table column order, and dumps raw sub-summary dicts for field-mapping validation. No names or IDs hardcoded.

  # Frontend

  - Settings page — new "SleepHQ Integration" card with Client ID, Client Secret, and Team ID fields; loads  existing settings on mount; saves via PUT /import/settings
  - Import page — new "Sync from SleepHQ" card with a Sync now button that calls POST /import/trigger; links to Settings for first-time setup
  - API client — ImportSettings interface + getImportSettings, saveImportSettings, triggerSleepHQImport  methods

 #  Docs
  - New SleepHQ Import section in README covering env var setup, UI sync, and CLI usage
  - .gitignore updated to exclude uv.lock / .python-version

#  Test plan

  - SLEEPHQ_CLIENT_ID=... SLEEPHQ_CLIENT_SECRET=... SLEEPHQ_TEAM_IDS=<id> python3
  importer/test_sleephq_fetch.py prints a populated sessions table with no — in AHI/pressure columns
  - Re-running skips existing rows (incremental); --force overwrites
  - Settings page loads, saves, and reloads SleepHQ credentials
  - Import page Sync now returns a success message with valid credentials
  - Import page Sync now returns a clear error with missing/invalid credentials
  - Long back-fill (--days 365) completes without manual intervention despite rate limiting