### PR TITLE
feat: server-path import — settings, trigger endpoints, scheduling docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ psql -d cpap -f migrations/002_scope_sessions_per_user.sql
 psql -d cpap -f migrations/003_add_public_ids.sql
 psql -d cpap -f migrations/004_reset_uuid_ids.sql
 psql -d cpap -f migrations/005_add_user_profile_fields.sql
+psql -d cpap -f migrations/006_add_import_settings.sql
 ```
 
 ### 4. Run the app
@@ -322,6 +323,53 @@ Optional filters:
 python3.12 import_sessions.py --datalog /absolute/path/to/DATALOG --user-id <user-uuid> --folder 20241215
 python3.12 import_sessions.py --datalog /absolute/path/to/DATALOG --user-id <user-uuid> --from 20250101
 ```
+
+## Server-Path Import
+
+For self-hosted deployments, SleepLab can import from a DATALOG directory mounted directly on the server — useful for a NAS share, rsync'd SD card, or Home Assistant automation.
+
+### Setup
+
+1. Mount your CPAP data directory into the container under `/data/imports`:
+
+   ```yaml
+   # docker-compose.yml
+   services:
+     app:
+       volumes:
+         - /mnt/nas/cpap:/data/imports:ro
+       environment:
+         IMPORT_BASE_DIR: /data/imports
+   ```
+
+2. In **Settings → Server Import**, enter the path to your DATALOG folder (e.g. `/data/imports/DATALOG`), choose a poll frequency, and save.
+
+3. Click **Import → Import from Server Path → Import now** to run immediately, or set up a cron job / webhook to run on schedule.
+
+### Scheduled imports (cron)
+
+```cron
+# Run daily at 06:00 — adjust IMPORT_WEBHOOK_SECRET and URL as needed
+0 6 * * * curl -sf -X POST http://localhost:8000/import/trigger/all \
+  -H "Authorization: Bearer $IMPORT_WEBHOOK_SECRET"
+```
+
+Set `IMPORT_WEBHOOK_SECRET` in your environment or `.env` file to a random string (`openssl rand -hex 32`). The `/import/trigger/all` endpoint fires background imports for every user with auto-import enabled.
+
+### Webhook trigger
+
+Any HTTP client (Home Assistant, n8n, etc.) can trigger imports:
+
+```
+POST /import/trigger/all
+Authorization: Bearer <IMPORT_WEBHOOK_SECRET>
+```
+
+### Security
+
+- `datalog_path` is resolved and validated against `IMPORT_BASE_DIR`; paths outside that root are rejected.
+- The host volume is recommended as read-only (`:ro`).
+- `IMPORT_WEBHOOK_SECRET` must be set for the `/trigger/all` endpoint to accept requests.
 
 ## AI Summaries
 

--- a/api/main.py
+++ b/api/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .routers import auth as auth_router
-from .routers import sessions, stats, upload, ai_summary
+from .routers import sessions, stats, upload, ai_summary, local_import
 from .env import load_env
 
 load_env()
@@ -41,6 +41,7 @@ app.include_router(stats.router, prefix="/stats", tags=["stats"])
 app.include_router(auth_router.router, prefix="/auth", tags=["auth"])
 app.include_router(upload.router, prefix="/upload", tags=["upload"])
 app.include_router(ai_summary.router, prefix="/stats", tags=["stats"])
+app.include_router(local_import.router, prefix="/import", tags=["import"])
 
 
 @app.get("/health")

--- a/api/routers/local_import.py
+++ b/api/routers/local_import.py
@@ -1,0 +1,310 @@
+"""
+Server-path import router.
+
+Endpoints
+---------
+GET  /import/settings          Read own import configuration (JWT)
+PUT  /import/settings          Create / update own import configuration (JWT)
+GET  /import/status            Last import result for the current user (JWT)
+POST /import/trigger           Run an import now for the current user (JWT)
+POST /import/trigger/all       Trigger all auto-import users (webhook secret)
+
+Environment variables
+---------------------
+IMPORT_BASE_DIR          Root directory that user datalog paths must be under.
+                         Defaults to /data/imports.  Any path submitted that
+                         does not resolve inside this directory is rejected.
+IMPORT_WEBHOOK_SECRET    Bearer token required for POST /import/trigger/all.
+                         When unset the endpoint returns 503.
+"""
+
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException
+from pydantic import BaseModel, field_validator
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from ..auth import get_current_user
+from ..database import get_db
+
+router = APIRouter()
+
+IMPORTER_SCRIPT = (
+    Path(__file__).resolve().parent.parent.parent / "importer" / "import_sessions.py"
+)
+IMPORT_BASE_DIR = Path(os.environ.get("IMPORT_BASE_DIR", "/data/imports"))
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+class ImportSettingsIn(BaseModel):
+    datalog_path: Optional[str] = None
+    auto_import_enabled: bool = False
+    poll_frequency: str = "daily"
+    lookback_days: int = 7
+
+    @field_validator("poll_frequency")
+    @classmethod
+    def _valid_frequency(cls, v: str) -> str:
+        if v not in ("hourly", "daily", "weekly"):
+            raise ValueError("poll_frequency must be 'hourly', 'daily', or 'weekly'")
+        return v
+
+    @field_validator("datalog_path")
+    @classmethod
+    def _safe_path(cls, v: Optional[str]) -> Optional[str]:
+        if v is None or v.strip() == "":
+            return None
+        resolved = Path(v).resolve()
+        try:
+            resolved.relative_to(IMPORT_BASE_DIR.resolve())
+        except ValueError:
+            raise ValueError(
+                f"datalog_path must be under {IMPORT_BASE_DIR}"
+            )
+        return str(resolved)
+
+    @field_validator("lookback_days")
+    @classmethod
+    def _valid_lookback(cls, v: int) -> int:
+        if not (1 <= v <= 365):
+            raise ValueError("lookback_days must be between 1 and 365")
+        return v
+
+
+class ImportSettingsOut(BaseModel):
+    datalog_path: Optional[str]
+    auto_import_enabled: bool
+    poll_frequency: str
+    lookback_days: int
+    last_import_at: Optional[str]
+    last_import_status: Optional[str]
+    last_import_message: Optional[str]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_settings(db: Session, user_id: str) -> Optional[dict]:
+    row = db.execute(
+        text("""
+            SELECT datalog_path, auto_import_enabled, poll_frequency, lookback_days,
+                   last_import_at, last_import_status, last_import_message
+            FROM user_import_settings
+            WHERE user_id = CAST(:uid AS uuid)
+        """),
+        {"uid": user_id},
+    ).mappings().first()
+    return dict(row) if row else None
+
+
+def _upsert_settings(db: Session, user_id: str, data: dict) -> None:
+    db.execute(
+        text("""
+            INSERT INTO user_import_settings
+                (user_id, datalog_path, auto_import_enabled, poll_frequency,
+                 lookback_days, updated_at)
+            VALUES
+                (CAST(:uid AS uuid), :datalog_path, :auto_import_enabled,
+                 :poll_frequency, :lookback_days, NOW())
+            ON CONFLICT (user_id) DO UPDATE SET
+                datalog_path        = EXCLUDED.datalog_path,
+                auto_import_enabled = EXCLUDED.auto_import_enabled,
+                poll_frequency      = EXCLUDED.poll_frequency,
+                lookback_days       = EXCLUDED.lookback_days,
+                updated_at          = NOW()
+        """),
+        {"uid": user_id, **data},
+    )
+    db.commit()
+
+
+def _record_import_result(
+    db: Session,
+    user_id: str,
+    status: str,
+    message: str,
+) -> None:
+    db.execute(
+        text("""
+            UPDATE user_import_settings
+            SET last_import_at      = NOW(),
+                last_import_status  = :status,
+                last_import_message = :message,
+                updated_at          = NOW()
+            WHERE user_id = CAST(:uid AS uuid)
+        """),
+        {"uid": user_id, "status": status, "message": message},
+    )
+    db.commit()
+
+
+def _run_local_import(user_id: str, datalog_path: str, lookback_days: int) -> None:
+    """Background task: run import_sessions.py for a server-mounted DATALOG path."""
+    from ..database import SessionLocal  # avoid circular import at module level
+
+    db = SessionLocal()
+    try:
+        _record_import_result(db, user_id, "running", "Import started")
+
+        cmd = [
+            sys.executable,
+            str(IMPORTER_SCRIPT),
+            "--datalog", datalog_path,
+            "--user-id", user_id,
+            "--from", _lookback_date(lookback_days),
+        ]
+        result = subprocess.run(
+            cmd,
+            cwd=str(IMPORTER_SCRIPT.parent),
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode == 0:
+            _record_import_result(db, user_id, "ok", result.stdout.strip()[-200:] or "Import complete")
+        else:
+            _record_import_result(db, user_id, "error", result.stderr.strip()[-200:] or "Import failed")
+    except Exception as exc:
+        _record_import_result(db, user_id, "error", str(exc)[:200])
+    finally:
+        db.close()
+
+
+def _lookback_date(days: int) -> str:
+    from datetime import timedelta
+    d = datetime.now(timezone.utc).date() - timedelta(days=days)
+    return d.strftime("%Y%m%d")
+
+
+def _require_webhook_secret(authorization: Optional[str] = Header(None)) -> None:
+    """Dependency: validate Bearer token against IMPORT_WEBHOOK_SECRET."""
+    secret = os.environ.get("IMPORT_WEBHOOK_SECRET", "")
+    if not secret:
+        raise HTTPException(status_code=503, detail="Webhook trigger is not configured on this server")
+    expected = f"Bearer {secret}"
+    if authorization != expected:
+        raise HTTPException(status_code=401, detail="Invalid or missing webhook secret")
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/settings", response_model=ImportSettingsOut)
+def get_import_settings(
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    row = _get_settings(db, current_user["id"])
+    if row is None:
+        return ImportSettingsOut(
+            datalog_path=None,
+            auto_import_enabled=False,
+            poll_frequency="daily",
+            lookback_days=7,
+            last_import_at=None,
+            last_import_status=None,
+            last_import_message=None,
+        )
+    return ImportSettingsOut(
+        **{k: (v.isoformat() if isinstance(v, datetime) else v) for k, v in row.items()}
+    )
+
+
+@router.put("/settings", response_model=ImportSettingsOut)
+def save_import_settings(
+    body: ImportSettingsIn,
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    _upsert_settings(db, current_user["id"], body.model_dump())
+    return get_import_settings(current_user=current_user, db=db)
+
+
+@router.get("/status")
+def get_import_status(
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    row = _get_settings(db, current_user["id"])
+    if row is None:
+        return {"last_import_at": None, "last_import_status": None, "last_import_message": None}
+    return {
+        "last_import_at": row["last_import_at"].isoformat() if row["last_import_at"] else None,
+        "last_import_status": row["last_import_status"],
+        "last_import_message": row["last_import_message"],
+    }
+
+
+@router.post("/trigger")
+def trigger_import(
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Trigger an immediate import for the current user using their saved datalog path."""
+    row = _get_settings(db, current_user["id"])
+    if not row or not row.get("datalog_path"):
+        raise HTTPException(
+            status_code=400,
+            detail="No datalog path configured. Set one in Settings first.",
+        )
+
+    path = row["datalog_path"]
+    if not Path(path).exists():
+        raise HTTPException(
+            status_code=400,
+            detail=f"Datalog path does not exist on the server: {path}",
+        )
+
+    background_tasks.add_task(
+        _run_local_import,
+        current_user["id"],
+        path,
+        row["lookback_days"],
+    )
+    return {"status": "accepted", "message": "Import started in the background."}
+
+
+@router.post("/trigger/all")
+def trigger_all_imports(
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+    _: None = Depends(_require_webhook_secret),
+):
+    """
+    Trigger imports for every user with auto_import_enabled = true.
+    Secured by IMPORT_WEBHOOK_SECRET bearer token.
+    """
+    rows = db.execute(
+        text("""
+            SELECT user_id::text AS user_id, datalog_path, lookback_days
+            FROM user_import_settings
+            WHERE auto_import_enabled = TRUE
+              AND datalog_path IS NOT NULL
+        """)
+    ).mappings().all()
+
+    queued = 0
+    for row in rows:
+        path = row["datalog_path"]
+        if Path(path).exists():
+            background_tasks.add_task(
+                _run_local_import,
+                row["user_id"],
+                path,
+                row["lookback_days"],
+            )
+            queued += 1
+
+    return {"status": "accepted", "queued": queued}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -141,6 +141,16 @@ export interface DailyStat {
   session_id: string
 }
 
+export interface LocalImportSettings {
+  datalog_path: string | null
+  auto_import_enabled: boolean
+  poll_frequency: 'hourly' | 'daily' | 'weekly'
+  lookback_days: number
+  last_import_at: string | null
+  last_import_status: 'ok' | 'error' | 'running' | null
+  last_import_message: string | null
+}
+
 export interface SummaryStats {
   total_nights: number
   nights_with_data: number
@@ -266,6 +276,10 @@ export const api = {
   },
   finishImportUpload: (uploadId: string) => post<ImportResponse>(`/upload/datalog/${uploadId}/finish`),
   getImportStatus: () => get<ImportStatusResponse>('/upload/status'),
+  getLocalImportSettings: () => get<LocalImportSettings>('/import/settings'),
+  saveLocalImportSettings: (payload: Partial<LocalImportSettings>) =>
+    put<LocalImportSettings>('/import/settings', payload),
+  triggerLocalImport: () => post<{ status: string; message: string }>('/import/trigger'),
 }
 
 export const authTokenStore = {

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, type ChangeEvent, type FormEvent } from 'react'
+import { Link } from 'react-router-dom'
 
 import { api } from '../api/client'
 import { CheckCircleIcon } from '../components/icons/ChevronIcons'
@@ -117,8 +118,27 @@ export default function Import() {
 
   const uploadPercent = totalFiles > 0 ? Math.round((uploadedFiles / totalFiles) * 100) : 0
 
+  // Server-path import
+  const [isServerImporting, setIsServerImporting] = useState(false)
+  const [serverImportMessage, setServerImportMessage] = useState<string | null>(null)
+  const [serverImportError, setServerImportError] = useState<string | null>(null)
+
+  async function handleServerImport() {
+    setServerImportError(null)
+    setServerImportMessage(null)
+    setIsServerImporting(true)
+    try {
+      const result = await api.triggerLocalImport()
+      setServerImportMessage(result.message)
+    } catch (err) {
+      setServerImportError(err instanceof Error ? err.message : 'Import failed')
+    } finally {
+      setIsServerImporting(false)
+    }
+  }
+
   return (
-    <div className="mx-auto max-w-2xl">
+    <div className="mx-auto max-w-2xl space-y-6">
       <Card className="bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.6),_transparent_38%),var(--surface-strong)]">
         <CardHeader>
           <CardTitle className="text-2xl">Import Sleep Data</CardTitle>
@@ -189,6 +209,30 @@ export default function Import() {
               {isSubmitting ? 'Uploading...' : 'Start import'}
             </Button>
           </form>
+        </CardContent>
+      </Card>
+      <Card className="bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.45),_transparent_38%),var(--surface-strong)]">
+        <CardHeader>
+          <CardTitle className="text-2xl">Import from Server Path</CardTitle>
+          <CardDescription>
+            Trigger an immediate import from the DATALOG directory mounted on the server. Configure the
+            path and schedule in{' '}
+            <Link className="font-medium text-[var(--foreground)] underline underline-offset-2" to="/settings">
+              Settings
+            </Link>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {serverImportMessage ? (
+            <div className="flex items-start gap-3 rounded-[20px] border border-[rgba(106,161,54,0.24)] bg-[rgba(106,161,54,0.1)] p-4 text-[var(--olive-deep)]">
+              <CheckCircleIcon className="mt-0.5 h-5 w-5 shrink-0" />
+              <p className="text-sm font-medium">{serverImportMessage}</p>
+            </div>
+          ) : null}
+          {serverImportError ? <p className="text-sm text-[var(--danger-text)]">{serverImportError}</p> : null}
+          <Button onClick={handleServerImport} disabled={isServerImporting}>
+            {isServerImporting ? 'Starting...' : 'Import now'}
+          </Button>
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,12 +1,18 @@
 import { useEffect, useState, type FormEvent } from 'react'
 import { Navigate } from 'react-router-dom'
 
-import { api } from '../api/client'
+import { api, type LocalImportSettings } from '../api/client'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
 import { useAuth } from '../context/AuthContext'
+
+const FREQ_OPTIONS: { value: LocalImportSettings['poll_frequency']; label: string }[] = [
+  { value: 'hourly', label: 'Hourly' },
+  { value: 'daily',  label: 'Daily'  },
+  { value: 'weekly', label: 'Weekly' },
+]
 
 export default function SettingsPage() {
   const { user, isLoading, updateProfile } = useAuth()
@@ -23,6 +29,16 @@ export default function SettingsPage() {
   const [passwordError, setPasswordError] = useState<string | null>(null)
   const [isPasswordSubmitting, setIsPasswordSubmitting] = useState(false)
 
+  // Server-path import settings
+  const [datalогPath, setDatalогPath] = useState('')
+  const [autoImport, setAutoImport] = useState(false)
+  const [pollFrequency, setPollFrequency] = useState<LocalImportSettings['poll_frequency']>('daily')
+  const [lookbackDays, setLookbackDays] = useState(7)
+  const [importStatus, setImportStatus] = useState<LocalImportSettings | null>(null)
+  const [importMessage, setImportMessage] = useState<string | null>(null)
+  const [importError, setImportError] = useState<string | null>(null)
+  const [isImportSubmitting, setIsImportSubmitting] = useState(false)
+
   useEffect(() => {
     if (!user) {
       return
@@ -31,6 +47,16 @@ export default function SettingsPage() {
     setLastName(user.last_name)
     setEmail(user.email)
   }, [user])
+
+  useEffect(() => {
+    api.getLocalImportSettings().then((s) => {
+      setDatalогPath(s.datalog_path ?? '')
+      setAutoImport(s.auto_import_enabled)
+      setPollFrequency(s.poll_frequency)
+      setLookbackDays(s.lookback_days)
+      setImportStatus(s)
+    }).catch(() => {/* no settings yet */})
+  }, [])
 
   if (!isLoading && !user) {
     return <Navigate to="/login" replace />
@@ -83,6 +109,31 @@ export default function SettingsPage() {
       setIsPasswordSubmitting(false)
     }
   }
+
+  async function handleImportSettingsSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setImportError(null)
+    setImportMessage(null)
+    setIsImportSubmitting(true)
+    try {
+      const updated = await api.saveLocalImportSettings({
+        datalog_path: datalогPath.trim() || null,
+        auto_import_enabled: autoImport,
+        poll_frequency: pollFrequency,
+        lookback_days: lookbackDays,
+      })
+      setImportStatus(updated)
+      setImportMessage('Settings saved.')
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : 'Could not save settings')
+    } finally {
+      setIsImportSubmitting(false)
+    }
+  }
+
+  const lastRun = importStatus?.last_import_at
+    ? new Date(importStatus.last_import_at).toLocaleString()
+    : null
 
   return (
     <div className="mx-auto max-w-2xl space-y-6">
@@ -185,6 +236,89 @@ export default function SettingsPage() {
 
             <Button type="submit" disabled={isPasswordSubmitting}>
               {isPasswordSubmitting ? 'Updating password...' : 'Update password'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+      <Card className="bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.45),_transparent_38%),var(--surface-strong)]">
+        <CardHeader>
+          <CardTitle className="text-2xl">Server Import</CardTitle>
+          <CardDescription>
+            Point SleepLab at a DATALOG directory mounted on the server (e.g. a NAS share or rsync'd SD card).
+            The path must be inside the container's <code className="font-mono text-xs">/data/imports</code> mount.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-5" onSubmit={handleImportSettingsSubmit}>
+            <div className="space-y-3">
+              <Label htmlFor="datalогPath">DATALOG path</Label>
+              <Input
+                id="datalогPath"
+                value={datalогPath}
+                onChange={(e) => setDatalогPath(e.target.value)}
+                placeholder="/data/imports/your-uuid/DATALOG"
+                autoComplete="off"
+              />
+            </div>
+
+            <div className="space-y-3">
+              <Label>Poll frequency</Label>
+              <div className="flex gap-4">
+                {FREQ_OPTIONS.map((opt) => (
+                  <label key={opt.value} className="flex cursor-pointer items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="pollFrequency"
+                      value={opt.value}
+                      checked={pollFrequency === opt.value}
+                      onChange={() => setPollFrequency(opt.value)}
+                      className="accent-[var(--accent)]"
+                    />
+                    {opt.label}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <Label htmlFor="lookbackDays">Lookback days</Label>
+              <Input
+                id="lookbackDays"
+                type="number"
+                min={1}
+                max={365}
+                value={lookbackDays}
+                onChange={(e) => setLookbackDays(Number(e.target.value))}
+                className="w-28"
+              />
+            </div>
+
+            <div className="flex items-center gap-3">
+              <input
+                id="autoImport"
+                type="checkbox"
+                checked={autoImport}
+                onChange={(e) => setAutoImport(e.target.checked)}
+                className="h-4 w-4 accent-[var(--accent)]"
+              />
+              <Label htmlFor="autoImport" className="cursor-pointer">
+                Enable automatic import on the configured schedule
+              </Label>
+            </div>
+
+            {lastRun ? (
+              <p className="text-xs text-[var(--muted-foreground)]">
+                Last import: {lastRun}
+                {importStatus?.last_import_status ? ` — ${importStatus.last_import_status}` : ''}
+                {importStatus?.last_import_message ? ` · ${importStatus.last_import_message}` : ''}
+              </p>
+            ) : null}
+
+            {importMessage ? <p className="text-sm font-medium text-[var(--olive-deep)]">{importMessage}</p> : null}
+            {importError ? <p className="text-sm text-[var(--danger-text)]">{importError}</p> : null}
+
+            <Button type="submit" disabled={isImportSubmitting}>
+              {isImportSubmitting ? 'Saving...' : 'Save import settings'}
             </Button>
           </form>
         </CardContent>

--- a/migrations/006_add_import_settings.sql
+++ b/migrations/006_add_import_settings.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+-- Per-user configuration for server-path (local filesystem) imports.
+-- datalog_path must point to a DATALOG directory mounted into the container.
+-- poll_frequency controls how often an external cron job or webhook should
+-- trigger imports ('hourly', 'daily', 'weekly').
+CREATE TABLE IF NOT EXISTS user_import_settings (
+    id                  SERIAL PRIMARY KEY,
+    user_id             UUID NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+
+    -- Filesystem import
+    datalog_path        TEXT,
+    auto_import_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    poll_frequency      TEXT    NOT NULL DEFAULT 'daily'
+                        CHECK (poll_frequency IN ('hourly', 'daily', 'weekly')),
+    lookback_days       INTEGER NOT NULL DEFAULT 7,
+
+    -- Bookkeeping
+    last_import_at      TIMESTAMPTZ,
+    last_import_status  TEXT,    -- 'ok' | 'error' | 'running'
+    last_import_message TEXT,
+
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMIT;


### PR DESCRIPTION
#  Summary

  - New user_import_settings table stores each user's DATALOG path, poll frequency (hourly/daily/weekly), lookback window, and last-import bookkeeping
  - 5 new API endpoints under /import/: read/write settings, import status, per-user trigger (JWT), and a webhook endpoint (/import/trigger/all) that fires background imports for all auto-import-enabled users
  - Path-traversal guard: datalog_path is resolved and checked against IMPORT_BASE_DIR; anything outside is rejected with a 400
  - Settings UI: new card with DATALOG path field, poll-frequency radio (hourly/daily/weekly), lookback days, and auto-import toggle — shows last run status inline
  - Import UI: new "Import from Server Path" card with an Import now button
  - README: Docker volume setup, cron example, webhook trigger docs, and security notes

#  Test plan

  - PUT /import/settings with a path outside IMPORT_BASE_DIR returns 400
  - PUT /import/settings with a valid path saves and GET /import/settings returns it
  - POST /import/trigger starts a background import and GET /import/status reflects running then ok/error
  - POST /import/trigger/all with no IMPORT_WEBHOOK_SECRET set returns 503
  - POST /import/trigger/all with wrong secret returns 401
  - POST /import/trigger/all with correct secret queues jobs for all auto_import_enabled users
  - Settings page saves and reloads config correctly
  - Import now button shows success/error inline