### PR TITLE
feat: provider-agnostic LLM backend — support Ollama, LiteLLM, and custom endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Migrations run automatically through [`server.py`](/Users/joshuanissenbaum/Deskt
 - If Docker Compose says the image is missing, run `docker login` and `docker compose pull`.
 - If the frontend loads but API requests fail, verify `API_URL` and `CORS_ALLOWED_ORIGINS`.
 - If the API container exits early, inspect `docker compose logs app` for DB or migration errors.
-- If AI summaries are unavailable, confirm `OPENAI_API_KEY` is set.
+- If AI summaries are unavailable, check `GET /llm/health` for provider status and confirm the relevant env vars are set (see **AI Summaries** below).
 - If you are deploying to a Linux server, use the published multi-arch image tag rather than an old locally built arm-only image.
 
 ## Quick Start
@@ -325,9 +325,43 @@ python3.12 import_sessions.py --datalog /absolute/path/to/DATALOG --user-id <use
 
 ## AI Summaries
 
-Some summary endpoints depend on `OPENAI_API_KEY`.
+AI-generated session and trend summaries are powered by any OpenAI-compatible LLM backend. The provider is selected automatically based on environment variables — existing deployments with `OPENAI_API_KEY` continue to work with no changes.
 
-Without it, core dashboard features still work, but AI summary endpoints will not return generated output.
+### Provider detection
+
+| `LLM_PROVIDER` | Backend | Key env vars |
+|---|---|---|
+| `openai` (or auto-detected) | OpenAI cloud | `OPENAI_API_KEY`, `OPENAI_MODEL` (default `gpt-4o`) |
+| `ollama` (default when no key) | Local Ollama | `OLLAMA_BASE_URL` (default `http://localhost:11434/v1`), `OLLAMA_MODEL` (default `llama3.1:8b`) |
+| `litellm` | LiteLLM proxy | `LITELLM_BASE_URL` (default `http://localhost:4000/v1`), `LITELLM_MODEL` |
+| `custom` | Any OpenAI-compatible endpoint | `LLM_BASE_URL`, `LLM_API_KEY`, `LLM_MODEL` |
+
+### Health check
+
+```
+GET /llm/health
+```
+
+Returns the active provider, base URL, model, and whether the backend is reachable.
+
+### Self-hosted with Ollama
+
+```yaml
+# docker-compose.yml
+services:
+  app:
+    environment:
+      LLM_PROVIDER: ollama
+      OLLAMA_BASE_URL: http://ollama:11434/v1
+      OLLAMA_MODEL: llama3.1:8b
+  ollama:
+    image: ollama/ollama:latest
+    restart: unless-stopped
+    volumes:
+      - ollama_data:/root/.ollama
+```
+
+Without any LLM configuration, core dashboard features still work but AI summary endpoints return an error message instead of generated output.
 
 ## Project Layout
 

--- a/README.md
+++ b/README.md
@@ -329,11 +329,11 @@ AI-generated session and trend summaries are powered by any OpenAI-compatible LL
 
 ### Provider detection
 
-| `LLM_PROVIDER` | Backend | Key env vars |
+| `LLM_PROVIDER` | Backend | Required env vars |
 |---|---|---|
-| `openai` (or auto-detected) | OpenAI cloud | `OPENAI_API_KEY`, `OPENAI_MODEL` (default `gpt-4o`) |
-| `ollama` (default when no key) | Local Ollama | `OLLAMA_BASE_URL` (default `http://localhost:11434/v1`), `OLLAMA_MODEL` (default `llama3.1:8b`) |
-| `litellm` | LiteLLM proxy | `LITELLM_BASE_URL` (default `http://localhost:4000/v1`), `LITELLM_MODEL` |
+| `openai` / auto-detected | OpenAI cloud | `OPENAI_API_KEY`, `OPENAI_MODEL` (default `gpt-4o`) |
+| `ollama` / default when no key | Local Ollama | `OLLAMA_BASE_URL` (default `http://localhost:11434/v1`), `OLLAMA_MODEL` (default `llama3.1:8b`) |
+| `litellm` | LiteLLM proxy | `LITELLM_BASE_URL` (default `http://localhost:4000/v1`), `LITELLM_MODEL` (default `gpt-4o-mini`) |
 | `custom` | Any OpenAI-compatible endpoint | `LLM_BASE_URL`, `LLM_API_KEY`, `LLM_MODEL` |
 
 ### Health check

--- a/api/llm_client.py
+++ b/api/llm_client.py
@@ -1,0 +1,95 @@
+"""
+Provider-agnostic LLM client factory.
+
+All supported backends (OpenAI, Ollama, LiteLLM, custom) expose the
+OpenAI-compatible /v1/chat/completions protocol, so the official openai
+Python SDK can drive all of them — only base_url and api_key differ.
+
+Provider detection
+------------------
+LLM_PROVIDER set explicitly?
+  "openai"  → OPENAI_API_KEY + api.openai.com
+  "ollama"  → OLLAMA_BASE_URL (default http://localhost:11434/v1), key "ollama"
+  "litellm" → LITELLM_BASE_URL (default http://localhost:4000/v1), LITELLM_API_KEY
+  "custom"  → LLM_BASE_URL + LLM_API_KEY (both required)
+
+LLM_PROVIDER not set?
+  OPENAI_API_KEY present → "openai"   (backwards compatible with existing deploys)
+  otherwise              → "ollama"   (self-hosted default)
+
+Environment variables
+---------------------
+LLM_PROVIDER      one of: openai, ollama, litellm, custom  (optional)
+OPENAI_API_KEY    required for openai provider
+OPENAI_MODEL      default: gpt-4o
+OLLAMA_BASE_URL   default: http://localhost:11434/v1
+OLLAMA_MODEL      default: llama3.1:8b
+LITELLM_BASE_URL  default: http://localhost:4000/v1
+LITELLM_MODEL     default: gpt-4o-mini
+LLM_BASE_URL      required for custom provider
+LLM_API_KEY       required for custom provider
+LLM_MODEL         required for custom provider
+"""
+
+import os
+from openai import OpenAI
+
+
+def get_provider() -> str:
+    """Return the active provider name, auto-detecting when LLM_PROVIDER is unset."""
+    explicit = os.environ.get("LLM_PROVIDER", "").strip().lower()
+    if explicit:
+        return explicit
+    if os.environ.get("OPENAI_API_KEY"):
+        return "openai"
+    return "ollama"
+
+
+def get_llm_client() -> OpenAI:
+    """Return an OpenAI-SDK client pointed at the configured backend."""
+    provider = get_provider()
+
+    if provider == "openai":
+        return OpenAI(api_key=os.environ.get("OPENAI_API_KEY", ""))
+
+    if provider == "ollama":
+        base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+        return OpenAI(base_url=base_url, api_key="ollama")
+
+    if provider == "litellm":
+        base_url = os.environ.get("LITELLM_BASE_URL", "http://localhost:4000/v1")
+        api_key = os.environ.get("LITELLM_API_KEY", "litellm")
+        return OpenAI(base_url=base_url, api_key=api_key)
+
+    if provider == "custom":
+        base_url = os.environ.get("LLM_BASE_URL", "")
+        api_key = os.environ.get("LLM_API_KEY", "custom")
+        if not base_url:
+            raise ValueError("LLM_BASE_URL must be set when LLM_PROVIDER=custom")
+        return OpenAI(base_url=base_url, api_key=api_key)
+
+    raise ValueError(f"Unknown LLM_PROVIDER: {provider!r}")
+
+
+def get_model() -> str:
+    """Return the model name to use for the configured provider."""
+    provider = get_provider()
+
+    defaults = {
+        "openai":   ("OPENAI_MODEL",   "gpt-4o"),
+        "ollama":   ("OLLAMA_MODEL",   "llama3.1:8b"),
+        "litellm":  ("LITELLM_MODEL",  "gpt-4o-mini"),
+        "custom":   ("LLM_MODEL",      ""),
+    }
+    env_var, fallback = defaults.get(provider, ("LLM_MODEL", ""))
+    return os.environ.get(env_var, fallback)
+
+
+def is_configured() -> bool:
+    """Return True if the backend has the minimum required configuration."""
+    provider = get_provider()
+    if provider == "openai":
+        return bool(os.environ.get("OPENAI_API_KEY"))
+    if provider == "custom":
+        return bool(os.environ.get("LLM_BASE_URL")) and bool(os.environ.get("LLM_MODEL"))
+    return True  # ollama / litellm just need a reachable URL

--- a/api/main.py
+++ b/api/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .routers import auth as auth_router
-from .routers import sessions, stats, upload, ai_summary
+from .routers import sessions, stats, upload, ai_summary, llm
 from .env import load_env
 
 load_env()
@@ -41,6 +41,7 @@ app.include_router(stats.router, prefix="/stats", tags=["stats"])
 app.include_router(auth_router.router, prefix="/auth", tags=["auth"])
 app.include_router(upload.router, prefix="/upload", tags=["upload"])
 app.include_router(ai_summary.router, prefix="/stats", tags=["stats"])
+app.include_router(llm.router, prefix="/llm", tags=["llm"])
 
 
 @app.get("/health")

--- a/api/routers/ai_summary.py
+++ b/api/routers/ai_summary.py
@@ -1,16 +1,15 @@
 import json
-import os
 from datetime import date, timedelta
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from openai import OpenAI
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from ..auth import get_current_user
 from ..database import get_db
+from ..llm_client import get_llm_client, get_model, is_configured
 
 router = APIRouter()
 
@@ -45,9 +44,8 @@ def get_ai_summary(
     current_user: dict = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    api_key = os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        return AISummaryResponse(error="OpenAI API key not configured")
+    if not is_configured():
+        return AISummaryResponse(error="LLM backend not configured")
 
     start_date = date.today() - timedelta(days=days - 1)
     row = db.execute(
@@ -165,15 +163,15 @@ def get_ai_summary(
     )
 
     try:
-        client = OpenAI(api_key=api_key)
-        response = client.responses.create(
-            model="gpt-4o",
-            input=[
+        client = get_llm_client()
+        response = client.chat.completions.create(
+            model=get_model(),
+            messages=[
                 {"role": "system", "content": SYSTEM_PROMPT},
                 {"role": "user", "content": user_prompt},
             ],
         )
-        payload = _parse_ai_payload((response.output_text or "").strip())
+        payload = _parse_ai_payload((response.choices[0].message.content or "").strip())
         return AISummaryResponse(
             insights=payload.get("insights"),
             going_well=_ensure_list(payload.get("going_well")),
@@ -256,9 +254,8 @@ def get_session_ai_summary(
     current_user: dict = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    api_key = os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        return SessionAISummaryResponse(error="OpenAI API key not configured")
+    if not is_configured():
+        return SessionAISummaryResponse(error="LLM backend not configured")
 
     row = db.execute(
         text(
@@ -298,15 +295,15 @@ def get_session_ai_summary(
     )
 
     try:
-        client = OpenAI(api_key=api_key)
-        response = client.responses.create(
-            model="gpt-4o",
-            input=[
+        client = get_llm_client()
+        response = client.chat.completions.create(
+            model=get_model(),
+            messages=[
                 {"role": "system", "content": SESSION_AI_SYSTEM_PROMPT},
                 {"role": "user", "content": user_prompt},
             ],
         )
-        payload = _parse_ai_payload((response.output_text or "").strip())
+        payload = _parse_ai_payload((response.choices[0].message.content or "").strip())
         return SessionAISummaryResponse(
             headline=payload.get("headline"),
             observations=_ensure_list(payload.get("observations")),
@@ -345,9 +342,8 @@ def get_trend_ai_summary(
     current_user: dict = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    api_key = os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        return TrendAISummaryResponse(error="OpenAI API key not configured")
+    if not is_configured():
+        return TrendAISummaryResponse(error="LLM backend not configured")
 
     rows = db.execute(
         text(
@@ -387,15 +383,15 @@ def get_trend_ai_summary(
     )
 
     try:
-        client = OpenAI(api_key=api_key)
-        response = client.responses.create(
-            model="gpt-4o",
-            input=[
+        client = get_llm_client()
+        response = client.chat.completions.create(
+            model=get_model(),
+            messages=[
                 {"role": "system", "content": TREND_AI_SYSTEM_PROMPT},
                 {"role": "user", "content": user_prompt},
             ],
         )
-        payload = _parse_ai_payload((response.output_text or "").strip())
+        payload = _parse_ai_payload((response.choices[0].message.content or "").strip())
         return TrendAISummaryResponse(
             headline=payload.get("headline"),
             anomalies=_ensure_list(payload.get("anomalies")),

--- a/api/routers/llm.py
+++ b/api/routers/llm.py
@@ -1,0 +1,43 @@
+"""
+LLM health endpoint.
+
+GET /llm/health  — returns provider name, base URL, model, and connectivity status.
+"""
+
+import os
+
+from fastapi import APIRouter
+
+from ..llm_client import get_llm_client, get_model, get_provider
+
+router = APIRouter()
+
+_BASE_URLS = {
+    "openai":  "https://api.openai.com/v1",
+    "ollama":  lambda: os.environ.get("OLLAMA_BASE_URL",  "http://localhost:11434/v1"),
+    "litellm": lambda: os.environ.get("LITELLM_BASE_URL", "http://localhost:4000/v1"),
+    "custom":  lambda: os.environ.get("LLM_BASE_URL",     ""),
+}
+
+
+@router.get("/health")
+def llm_health():
+    """Return provider info and a live connectivity check."""
+    provider = get_provider()
+    model = get_model()
+
+    entry = _BASE_URLS.get(provider, "")
+    base_url = entry() if callable(entry) else entry
+
+    try:
+        client = get_llm_client()
+        client.models.list()
+        return {"provider": provider, "base_url": base_url, "model": model, "ok": True}
+    except Exception as exc:
+        return {
+            "provider": provider,
+            "base_url": base_url,
+            "model": model,
+            "ok": False,
+            "error": str(exc)[:300],
+        }


### PR DESCRIPTION
  **Summary**

  - New api/llm_client.py factory selects the backend from LLM_PROVIDER. Auto-detects "openai" when OPENAI_API_KEY is present and falls back to "ollama" for self-hosted setups — no config required for either common case
  - All three AI summary endpoints updated to use get_llm_client() + chat.completions.create(messages=[...]), which is the shared protocol across OpenAI, Ollama, LiteLLM, and any custom endpoint
  - GET /llm/health returns provider name, base URL, model, and a live connectivity check
  - Zero breaking changes — existing deployments with only OPENAI_API_KEY set continue to work identically

  **Supported providers**

  | `LLM_PROVIDER` | Backend | Required env vars |
  |---|---|---|
  | `openai` / auto-detected | OpenAI cloud | `OPENAI_API_KEY`, `OPENAI_MODEL` (default `gpt-4o`) |
  | `ollama` / default when no key | Local Ollama | `OLLAMA_BASE_URL` (default `http://localhost:11434/v1`), `OLLAMA_MODEL` (default `llama3.1:8b`) |
  | `litellm` | LiteLLM proxy | `LITELLM_BASE_URL` (default `http://localhost:4000/v1`), `LITELLM_MODEL` (default `gpt-4o-mini`) |
  | `custom` | Any OpenAI-compatible endpoint | `LLM_BASE_URL`, `LLM_API_KEY`, `LLM_MODEL` |
  
  **Test plan**

  - With OPENAI_API_KEY set and no LLM_PROVIDER, AI summaries use OpenAI (backward compat)
  - With LLM_PROVIDER=ollama and a running Ollama instance, summaries route through it
  - GET /llm/health returns "ok": true when backend is reachable
  - GET /llm/health returns "ok": false with error detail when backend is down
  - AI summary endpoints return a clean error string (not a 500) when backend is unreachable
  - No OPENAI_API_KEY + no LLM_PROVIDER → auto-selects ollama, health check reflects that