### PR TITLE
fix: use PLD timestamp for session_id to support multiple sessions er date

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ In the UI:
 
 The upload/import endpoints are implemented in [`api/routers/upload.py`](/Users/joshuanissenbaum/Desktop/cpap-dashboard/api/routers/upload.py), and the importer lives in [`importer/import_sessions.py`](/Users/joshuanissenbaum/Desktop/cpap-dashboard/importer/import_sessions.py).
 
+Multiple therapy sessions on the same night (e.g. two separate mask-wearing periods) are each imported as distinct sessions identified by their PLD recording start time.
+
 You can also run the importer manually:
 
 ```bash

--- a/importer/import_sessions.py
+++ b/importer/import_sessions.py
@@ -135,10 +135,15 @@ def import_folder(folder: Path, folder_date: date, conn, user_id: str):
 
     imported = 0
     for block_idx, block in enumerate(blocks):
-        # Build human-readable session_id
-        # Format: "YYYYMMDD_HHMMSS" using folder date + CSL HHMMSS
-        csl_ts = block['csl_ts']
-        session_id = f"{folder_date.strftime('%Y%m%d')}_{csl_ts[8:10]}{csl_ts[10:12]}{csl_ts[12:14]}"
+        # Build session_id from the PLD timestamp (actual recording start), not the
+        # CSL timestamp.  Multiple PLD blocks within one folder can share a single
+        # CSL file; using the CSL time would produce duplicate session_ids and cause
+        # the second (and any further) session from the same night to be skipped.
+        # PLD timestamps are unique per recording block so this correctly supports
+        # multiple sessions on the same date.
+        # Format: "YYYYMMDD_HHMMSS" using folder date + PLD start HHMMSS
+        pld_ts = block['pld_ts']
+        session_id = f"{folder_date.strftime('%Y%m%d')}_{pld_ts[8:10]}{pld_ts[10:12]}{pld_ts[12:14]}"
 
         try:
             if session_exists(conn, user_id, session_id):


### PR DESCRIPTION
The session_id was built from the CSL (configuration) timestamp.  Multiple PLD recording blocks within one DATALOG folder can share a single CSL file, which caused every block after the first to receive the same session_id and be silently skipped on import.

Fix: derive session_id from the PLD timestamp instead.  Each PLD file represents one distinct recording session and carries a unique start time, so YYYYMMDD_PLDHHMMSS is guaranteed unique within a folder.

Note: this changes the session_id format for blocks where PLD start time differs from CSL start time.  Users re-running the importer after upgrading may see those sessions imported again under the corrected identifier.