### PR TITLE
feat: MACHINE_TZ / DISPLAY_TZ — correct EDF UTC storage and timezone-aware plot labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,28 @@ Default local URLs:
 - Frontend: `http://127.0.0.1:5173`
 - API: `http://127.0.0.1:8000`
 
+## Timezones
+
+Two IANA timezone settings control how session data is interpreted and displayed.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `MACHINE_TZ` | `UTC` | The timezone your CPAP machine is set to. The importer uses this to correctly interpret the naive local timestamps embedded in EDF files before storing them as UTC in the database. |
+| `DISPLAY_TZ` | `UTC` | The timezone used to format all time labels in the UI — plot axes, event timeline, session start time. Set this to your local timezone for accurate display. |
+
+Both values must be valid [IANA timezone names](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (e.g. `America/New_York`, `Europe/London`, `Australia/Sydney`).
+
+Set them in your `.env` file or `docker-compose.yml`:
+
+```env
+MACHINE_TZ=America/New_York
+DISPLAY_TZ=America/New_York
+```
+
+If your machine is set to the same timezone as your display, both values will be identical. If you travel with your CPAP and don't update the machine clock, set `MACHINE_TZ` to the machine's home timezone and `DISPLAY_TZ` to wherever you want times displayed.
+
+> **Re-importing after changing `MACHINE_TZ`:** The importer attaches the timezone at import time. If you change `MACHINE_TZ` after sessions are already in the database, re-run the importer with `--from` to update affected sessions.
+
 ## Auth
 
 SleepLab uses bearer-token auth.

--- a/api/main.py
+++ b/api/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .routers import auth as auth_router
-from .routers import sessions, stats, upload, ai_summary
+from .routers import sessions, stats, upload, ai_summary, config
 from .env import load_env
 
 load_env()
@@ -41,6 +41,7 @@ app.include_router(stats.router, prefix="/stats", tags=["stats"])
 app.include_router(auth_router.router, prefix="/auth", tags=["auth"])
 app.include_router(upload.router, prefix="/upload", tags=["upload"])
 app.include_router(ai_summary.router, prefix="/stats", tags=["stats"])
+app.include_router(config.router, prefix="/config", tags=["config"])
 
 
 @app.get("/health")

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -1,0 +1,30 @@
+"""
+App configuration endpoint.
+
+GET /config  — returns server-side settings the frontend needs at runtime,
+               including the display timezone for plot labels.
+"""
+
+import os
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("")
+def get_config():
+    """
+    Return runtime configuration for the frontend.
+
+    display_tz  IANA timezone name used to format all time labels in the UI
+                (plot axes, event timeline, session start time).  Defaults to UTC.
+
+    machine_tz  IANA timezone name the CPAP machine was set to when sessions
+                were recorded.  The importer uses this to correctly interpret
+                the naive local timestamps embedded in EDF files.  Defaults to UTC.
+    """
+    return {
+        "display_tz": os.environ.get("DISPLAY_TZ", "UTC"),
+        "machine_tz": os.environ.get("MACHINE_TZ", "UTC"),
+    }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,13 @@ services:
       API_URL: ${API_URL:-http://localhost:8000}
       API_HOST: 0.0.0.0
       API_PORT: 8000
+      # Timezone the CPAP machine is set to.  Used by the importer to correctly
+      # interpret naive local timestamps in EDF files before storing as UTC.
+      # Must be a valid IANA timezone name, e.g. America/New_York, Europe/London.
+      MACHINE_TZ: ${MACHINE_TZ:-UTC}
+      # Timezone used to format time labels on plots and session cards in the UI.
+      # Defaults to UTC; set to your local timezone for accurate display.
+      DISPLAY_TZ: ${DISPLAY_TZ:-UTC}
     ports:
       - "8080:8080"
       - "8000:8000"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { Link, Navigate, Route, Routes, useLocation, useNavigate } from 'react-r
 import { BrowserRouter } from 'react-router-dom'
 
 import { api } from './api/client'
+import { setDisplayTz } from './lib/displayTz'
 import {
   ActivityIcon,
   CalendarIcon,
@@ -79,6 +80,11 @@ function AppLayout() {
   const [isSyncing, setIsSyncing] = useState(false)
   const userMenuRef = useRef<HTMLDivElement | null>(null)
   const wasSyncingRef = useRef(false)
+
+  // Fetch display timezone from server config once on mount.
+  useEffect(() => {
+    api.getAppConfig().then((cfg) => setDisplayTz(cfg.display_tz)).catch(() => {})
+  }, [])
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -141,6 +141,11 @@ export interface DailyStat {
   session_id: string
 }
 
+export interface AppConfig {
+  display_tz: string
+  machine_tz: string
+}
+
 export interface SummaryStats {
   total_nights: number
   nights_with_data: number
@@ -266,6 +271,7 @@ export const api = {
   },
   finishImportUpload: (uploadId: string) => post<ImportResponse>(`/upload/datalog/${uploadId}/finish`),
   getImportStatus: () => get<ImportStatusResponse>('/upload/status'),
+  getAppConfig: () => get<AppConfig>('/config'),
 }
 
 export const authTokenStore = {

--- a/frontend/src/components/EventTimeline.tsx
+++ b/frontend/src/components/EventTimeline.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
 import type { EventRecord } from '../api/client'
+import { getDisplayTz } from '../lib/displayTz'
 
 interface Props {
   events: EventRecord[]
@@ -18,7 +19,7 @@ const EVENT_COLORS: Record<string, string> = {
 
 function fmtTime(startIso: string, offsetSeconds: number): string {
   const d = new Date(new Date(startIso).getTime() + offsetSeconds * 1000)
-  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: getDisplayTz() })
 }
 
 export default function EventTimeline({ events, durationSeconds, startDatetime }: Props) {

--- a/frontend/src/components/MetricsChart.tsx
+++ b/frontend/src/components/MetricsChart.tsx
@@ -3,6 +3,7 @@ import {
   Legend, ResponsiveContainer
 } from 'recharts'
 import type { MetricsResponse } from '../api/client'
+import { getDisplayTz } from '../lib/displayTz'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
 
 interface Props {
@@ -19,7 +20,7 @@ export default function MetricsChart({ metrics }: Props) {
   }))
 
   function fmtTs(ts: number) {
-    return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: getDisplayTz() })
   }
 
   return (

--- a/frontend/src/lib/displayTz.ts
+++ b/frontend/src/lib/displayTz.ts
@@ -1,0 +1,21 @@
+/**
+ * Module-level display timezone singleton.
+ *
+ * Initialised to the browser's local timezone so the app works correctly
+ * before the server config is fetched.  App.tsx overwrites it with the
+ * DISPLAY_TZ value from GET /config on startup.
+ *
+ * Usage:
+ *   import { getDisplayTz } from '../lib/displayTz'
+ *   new Date(ts).toLocaleTimeString([], { timeZone: getDisplayTz(), ... })
+ */
+
+let _tz: string = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+export function getDisplayTz(): string {
+  return _tz
+}
+
+export function setDisplayTz(tz: string): void {
+  _tz = tz
+}

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { api } from '../api/client'
+import { getDisplayTz } from '../lib/displayTz'
 import type { SessionDetail as SessionDetailType, EventRecord, MetricsResponse } from '../api/client'
 import { ChevronLeftIcon, ChevronRightIcon } from '../components/icons/ChevronIcons'
 import EventTimeline from '../components/EventTimeline'
@@ -11,11 +12,11 @@ import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
 
 function fmtDate(iso: string) {
-  return new Date(iso).toLocaleDateString([], { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })
+  return new Date(iso).toLocaleDateString([], { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', timeZone: getDisplayTz() })
 }
 
 function fmtTime(iso: string) {
-  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: getDisplayTz() })
 }
 
 

--- a/importer/import_sessions.py
+++ b/importer/import_sessions.py
@@ -8,11 +8,13 @@ Run:
     python import_sessions.py --from 20250101     # from date onward
 """
 
+import os
 import sys
 import argparse
 import statistics
 from pathlib import Path
 from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from edf_parser import parse_pld, parse_eve, parse_sa2, read_header
 from db import (
@@ -26,6 +28,21 @@ from db import (
 
 
 AHI_EVENT_TYPES = {'Central Apnea', 'Obstructive Apnea', 'Hypopnea', 'Apnea'}
+
+
+def _machine_tz() -> ZoneInfo:
+    """Return the ZoneInfo for MACHINE_TZ, falling back to UTC on invalid input."""
+    name = os.environ.get("MACHINE_TZ", "UTC")
+    try:
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, KeyError):
+        print(f"  WARNING: unknown MACHINE_TZ={name!r}, falling back to UTC", flush=True)
+        return ZoneInfo("UTC")
+
+
+def _localize(naive_dt: datetime) -> datetime:
+    """Attach MACHINE_TZ to a naive datetime from an EDF header."""
+    return naive_dt.replace(tzinfo=_machine_tz())
 
 
 def discover_session_blocks(folder: Path) -> list:
@@ -153,13 +170,15 @@ def import_folder(folder: Path, folder_date: date, conn, user_id: str):
             if block['eve_path'] and block['eve_path'].exists():
                 _, events = parse_eve(block['eve_path'])
 
-            # Get CSL start datetime for event absolute timestamps
-            csl_start = pld_header.start_datetime  # fallback
+            # Get CSL start datetime for event absolute timestamps.
+            # EDF timestamps are naive local machine time; attach MACHINE_TZ so
+            # psycopg2 stores the correct UTC equivalent in TIMESTAMPTZ columns.
+            csl_start = _localize(pld_header.start_datetime)  # fallback
             if block['csl_path'] and block['csl_path'].exists():
                 csl_hdr = read_header(str(block['csl_path']))
-                csl_start = csl_hdr.start_datetime
+                csl_start = _localize(csl_hdr.start_datetime)
 
-            pld_start = pld_header.start_datetime
+            pld_start = _localize(pld_header.start_datetime)
             duration_s = int(pld_header.num_records * pld_header.duration_per_record)
 
             # Parse SA2 (optional)


### PR DESCRIPTION
  **MACHINE_TZ — importer path:**
  - import_sessions.py now calls _localize(naive_dt) on every EDF start_datetime before touching the DB
  - zoneinfo.ZoneInfo(MACHINE_TZ) is attached, so psycopg2 writes the correct UTC value into the TIMESTAMPTZ columns instead of misinterpreting machine-local time as UTC
  - Falls back to UTC with a warning on invalid timezone names

  **DISPLAY_TZ — frontend path:**
  - New GET /config endpoint serves {display_tz, machine_tz} to the frontend
  - frontend/src/lib/displayTz.ts singleton is initialised to the browser's local timezone (safe fallback), then overwritten with the server value on app mount
  - Every time formatter — MetricsChart x-axis ticks, EventTimeline label row and tooltips, SessionDetail session header — passes timeZone: getDisplayTz() to toLocaleTimeString/toLocaleDateString