### PR TITLE
feat: wearable data ingestion, storage, and session-detail visualisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ psql -d cpap -f migrations/002_scope_sessions_per_user.sql
 psql -d cpap -f migrations/003_add_public_ids.sql
 psql -d cpap -f migrations/004_reset_uuid_ids.sql
 psql -d cpap -f migrations/005_add_user_profile_fields.sql
+psql -d cpap -f migrations/007_add_wearable_samples.sql
 ```
 
 ### 4. Run the app
@@ -322,6 +323,59 @@ Optional filters:
 python3.12 import_sessions.py --datalog /absolute/path/to/DATALOG --user-id <user-uuid> --folder 20241215
 python3.12 import_sessions.py --datalog /absolute/path/to/DATALOG --user-id <user-uuid> --from 20250101
 ```
+
+## Wearable Data
+
+SleepLab can display heart rate, SpO₂, and sleep stage data from external wearables alongside CPAP session data on the session detail page.
+
+### Supported devices
+
+Data can be ingested from any device that exports to JSON. Stage label normalisation is built-in for:
+
+| Device | Stage labels recognised |
+|---|---|
+| Withings | `deep_sleep`, `light_sleep`, `rem_sleep`, `awake` |
+| Oura Ring | `deep`, `light`, `rem`, `awake` |
+| Fitbit | `deep`, `light`, `rem`, `wake` |
+| Apple Watch / Health | `asleepDeep`, `asleepCore`, `asleepREM`, `awake`, `asleepUnspecified`, `inBed` |
+
+All labels are matched case-insensitively.
+
+### Sleep stage encoding
+
+| Value | Stage |
+|---|---|
+| 1 | Deep (N3 / SWS / slow-wave) |
+| 2 | Light (N1 / N2 / Core / unspecified) |
+| 3 | REM |
+| 4 | Awake |
+
+### Ingesting data
+
+```bash
+# Bulk upload samples via the API
+curl -X POST http://localhost:8000/wearable/samples \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source": "oura",
+    "samples": [
+      {"ts": "2025-01-15T22:00:00Z", "heart_rate": 62, "spo2": 97.5, "sleep_stage": "light"},
+      {"ts": "2025-01-15T22:30:00Z", "heart_rate": 58, "sleep_stage": "deep"}
+    ]
+  }'
+```
+
+Duplicate `(user, timestamp, source)` rows are upserted — safe to re-run exports.
+
+### Viewing data
+
+When wearable samples exist for a session date, two additional charts appear at the bottom of the session detail page:
+
+- **Heart Rate & SpO₂** — dual-axis line chart
+- **Sleep Stages** — step-style hypnogram (deep at bottom, awake at top)
+
+Charts are silently omitted when no wearable data is available for that date.
 
 ## AI Summaries
 

--- a/api/main.py
+++ b/api/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .routers import auth as auth_router
-from .routers import sessions, stats, upload, ai_summary
+from .routers import sessions, stats, upload, ai_summary, wearable
 from .env import load_env
 
 load_env()
@@ -41,6 +41,7 @@ app.include_router(stats.router, prefix="/stats", tags=["stats"])
 app.include_router(auth_router.router, prefix="/auth", tags=["auth"])
 app.include_router(upload.router, prefix="/upload", tags=["upload"])
 app.include_router(ai_summary.router, prefix="/stats", tags=["stats"])
+app.include_router(wearable.router, prefix="/wearable", tags=["wearable"])
 
 
 @app.get("/health")

--- a/api/routers/wearable.py
+++ b/api/routers/wearable.py
@@ -1,0 +1,223 @@
+"""
+Wearable data router.
+
+Accepts heart rate, SpO2, and sleep stage time-series from external devices
+(Withings, Oura Ring, Fitbit, Apple Watch/Health) and serves them back for
+display alongside CPAP session data.
+
+Sleep stage normalisation
+-------------------------
+All device-specific stage labels are mapped to a shared integer encoding:
+  1 = Deep    (N3 / SWS / slow-wave)
+  2 = Light   (N1 / N2 / Core / unspecified asleep)
+  3 = REM
+  4 = Awake   (in-bed but awake / out of bed)
+
+Supported source labels (case-insensitive, spaces and underscores ignored):
+
+  Withings :  'deep_sleep' | 'light_sleep' | 'rem_sleep' | 'awake'
+  Oura Ring:  'deep'       | 'light'       | 'rem'       | 'awake'
+  Fitbit   :  'deep'       | 'light'       | 'rem'       | 'wake'
+  Apple    :  'asleepdeep' | 'asleepcore'  | 'asleeprem' | 'awake' |
+              'asleepunspecified' | 'inbed'
+
+Endpoints
+---------
+POST /wearable/samples         Bulk upsert samples (JWT)
+GET  /wearable/samples         Query by date or date range (JWT)
+"""
+
+import re
+from datetime import date, datetime, timedelta
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from ..auth import get_current_user
+from ..database import get_db
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Sleep stage normalisation
+# ---------------------------------------------------------------------------
+
+def _key(s: str) -> str:
+    """Normalise a stage label to a lowercase alphanum key for lookup."""
+    return re.sub(r"[^a-z0-9]", "", s.lower())
+
+
+# Maps normalised label → integer stage value
+_STAGE_MAP: dict[str, int] = {
+    # Deep (1)
+    "deep": 1, "n3": 1, "sws": 1, "slowwave": 1, "deepsleep": 1,
+    "asleepdeep": 1,
+    # Light (2)
+    "light": 2, "n1": 2, "n2": 2, "core": 2, "lightsleep": 2,
+    "asleepcore": 2, "asleep": 2, "asleepunspecified": 2,
+    # REM (3)
+    "rem": 3, "remsleep": 3, "asleeprem": 3,
+    # Awake (4)
+    "awake": 4, "wake": 4, "inbed": 4, "in_bed": 4,
+}
+
+STAGE_LABELS = {1: "Deep", 2: "Light", 3: "REM", 4: "Awake"}
+
+
+def normalise_stage(raw: Optional[str]) -> Optional[int]:
+    if raw is None:
+        return None
+    return _STAGE_MAP.get(_key(raw))
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+class WearableSampleIn(BaseModel):
+    ts: datetime
+    heart_rate: Optional[int] = None   # bpm
+    spo2: Optional[float] = None       # %
+    sleep_stage: Optional[str] = None  # raw label from device
+
+
+class WearableBulkIn(BaseModel):
+    source: str                        # 'withings' | 'oura' | 'fitbit' | 'apple_health'
+    samples: List[WearableSampleIn]
+
+
+class WearableSampleOut(BaseModel):
+    ts: str
+    heart_rate: Optional[int]
+    spo2: Optional[float]
+    sleep_stage: Optional[int]
+    raw_stage: Optional[str]
+    source: Optional[str]
+
+
+class WearableResponse(BaseModel):
+    samples: List[WearableSampleOut]
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.post("/samples", status_code=204)
+def upsert_wearable_samples(
+    body: WearableBulkIn,
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Bulk upsert wearable samples for the current user.
+
+    Duplicate (user, ts, source) rows are updated in place.
+    Unknown sleep stage labels are stored as NULL in sleep_stage but
+    preserved verbatim in raw_stage.
+    """
+    if not body.samples:
+        return
+
+    source = body.source.strip().lower()
+    rows = []
+    for s in body.samples:
+        rows.append({
+            "uid":    current_user["id"],
+            "ts":     s.ts,
+            "hr":     s.heart_rate,
+            "spo2":   round(s.spo2, 2) if s.spo2 is not None else None,
+            "stage":  normalise_stage(s.sleep_stage),
+            "raw":    s.sleep_stage,
+            "source": source,
+        })
+
+    db.execute(
+        text("""
+            INSERT INTO wearable_samples
+                (user_id, ts, heart_rate, spo2, sleep_stage, raw_stage, source)
+            VALUES
+                (CAST(:uid AS uuid), :ts, :hr, :spo2, :stage, :raw, :source)
+            ON CONFLICT (user_id, ts, source) DO UPDATE SET
+                heart_rate  = COALESCE(EXCLUDED.heart_rate,  wearable_samples.heart_rate),
+                spo2        = COALESCE(EXCLUDED.spo2,        wearable_samples.spo2),
+                sleep_stage = COALESCE(EXCLUDED.sleep_stage, wearable_samples.sleep_stage),
+                raw_stage   = COALESCE(EXCLUDED.raw_stage,   wearable_samples.raw_stage)
+        """),
+        rows,
+    )
+    db.commit()
+
+
+@router.get("/samples", response_model=WearableResponse)
+def get_wearable_samples(
+    date: Optional[str] = Query(None, description="YYYY-MM-DD — fetch this calendar date plus the following morning (to cover sessions spanning midnight)"),
+    date_from: Optional[str] = Query(None, description="YYYY-MM-DD range start (inclusive)"),
+    date_to: Optional[str] = Query(None, description="YYYY-MM-DD range end (inclusive)"),
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Return wearable samples for the current user.
+
+    Provide either ?date=YYYY-MM-DD (single night — includes following morning
+    to cover sessions spanning midnight) or ?date_from=&date_to= for a range.
+    """
+    uid = current_user["id"]
+
+    if date is not None:
+        try:
+            d = datetime.strptime(date, "%Y-%m-%d").date()
+        except ValueError:
+            raise HTTPException(status_code=400, detail="date must be YYYY-MM-DD")
+        # Include the following morning so sessions that run past midnight are covered
+        ts_from = datetime(d.year, d.month, d.day)
+        ts_to   = datetime(d.year, d.month, d.day) + timedelta(hours=36)
+        rows = db.execute(
+            text("""
+                SELECT ts, heart_rate, spo2, sleep_stage, raw_stage, source
+                FROM wearable_samples
+                WHERE user_id = CAST(:uid AS uuid)
+                  AND ts >= :ts_from AND ts < :ts_to
+                ORDER BY ts
+            """),
+            {"uid": uid, "ts_from": ts_from, "ts_to": ts_to},
+        ).mappings().all()
+
+    elif date_from is not None:
+        try:
+            d_from = datetime.strptime(date_from, "%Y-%m-%d").date()
+            d_to   = datetime.strptime(date_to, "%Y-%m-%d").date() if date_to else d_from
+        except ValueError:
+            raise HTTPException(status_code=400, detail="dates must be YYYY-MM-DD")
+        rows = db.execute(
+            text("""
+                SELECT ts, heart_rate, spo2, sleep_stage, raw_stage, source
+                FROM wearable_samples
+                WHERE user_id = CAST(:uid AS uuid)
+                  AND ts::date BETWEEN :d_from AND :d_to
+                ORDER BY ts
+            """),
+            {"uid": uid, "d_from": d_from, "d_to": d_to},
+        ).mappings().all()
+
+    else:
+        raise HTTPException(status_code=400, detail="Provide ?date= or ?date_from=")
+
+    return WearableResponse(
+        samples=[
+            WearableSampleOut(
+                ts=r["ts"].isoformat(),
+                heart_rate=r["heart_rate"],
+                spo2=float(r["spo2"]) if r["spo2"] is not None else None,
+                sleep_stage=r["sleep_stage"],
+                raw_stage=r["raw_stage"],
+                source=r["source"],
+            )
+            for r in rows
+        ]
+    )

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -141,6 +141,32 @@ export interface DailyStat {
   session_id: string
 }
 
+export interface WearableSample {
+  ts: string
+  heart_rate: number | null
+  spo2: number | null
+  /** 1=Deep  2=Light  3=REM  4=Awake */
+  sleep_stage: 1 | 2 | 3 | 4 | null
+  raw_stage: string | null
+  source: string | null
+}
+
+export interface WearableResponse {
+  samples: WearableSample[]
+}
+
+export interface WearableSampleIn {
+  ts: string
+  heart_rate?: number | null
+  spo2?: number | null
+  sleep_stage?: string | null
+}
+
+export interface WearableBulkIn {
+  source: string
+  samples: WearableSampleIn[]
+}
+
 export interface SummaryStats {
   total_nights: number
   nights_with_data: number
@@ -266,6 +292,8 @@ export const api = {
   },
   finishImportUpload: (uploadId: string) => post<ImportResponse>(`/upload/datalog/${uploadId}/finish`),
   getImportStatus: () => get<ImportStatusResponse>('/upload/status'),
+  getWearableSamples: (date: string) => get<WearableResponse>('/wearable/samples', { date }),
+  postWearableSamples: (payload: WearableBulkIn) => post<void>('/wearable/samples', payload),
 }
 
 export const authTokenStore = {

--- a/frontend/src/components/SleepStageChart.tsx
+++ b/frontend/src/components/SleepStageChart.tsx
@@ -1,0 +1,117 @@
+/**
+ * Sleep stage hypnogram.
+ *
+ * Renders a step chart where the Y-axis has four discrete levels:
+ *   4 = Awake   (top)
+ *   3 = REM
+ *   2 = Light
+ *   1 = Deep    (bottom)
+ *
+ * This mirrors the conventional hypnogram orientation: deeper sleep is
+ * visually lower on the chart.
+ */
+
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid,
+  Tooltip, ResponsiveContainer,
+} from 'recharts'
+import type { WearableSample } from '../api/client'
+import { getDisplayTz } from '../lib/displayTz'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+
+interface Props {
+  samples: WearableSample[]
+}
+
+const STAGE_LABELS: Record<number, string> = {
+  1: 'Deep',
+  2: 'Light',
+  3: 'REM',
+  4: 'Awake',
+}
+
+const STAGE_COLORS: Record<number, string> = {
+  1: '#5251a7',  // deep — indigo
+  2: '#38bdf8',  // light — sky
+  3: '#4ade80',  // rem   — green
+  4: '#94a3b8',  // awake — slate
+}
+
+function fmtTs(ts: number) {
+  return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: getDisplayTz() })
+}
+
+// Custom dot that colours each point by its stage value
+function StageDot(props: { cx?: number; cy?: number; payload?: { stage: number | null } }) {
+  const { cx, cy, payload } = props
+  if (!payload?.stage || cx == null || cy == null) return null
+  return <circle cx={cx} cy={cy} r={2} fill={STAGE_COLORS[payload.stage] ?? '#94a3b8'} />
+}
+
+export default function SleepStageChart({ samples }: Props) {
+  const data = samples
+    .filter(s => s.sleep_stage !== null)
+    .map(s => ({
+      ts:    new Date(s.ts).getTime(),
+      stage: s.sleep_stage,
+    }))
+
+  if (data.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Sleep Stages</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {/* Legend */}
+        <div className="mb-3 flex flex-wrap gap-3 text-xs text-[var(--muted-foreground)]">
+          {([4, 3, 2, 1] as const).map(stage => (
+            <span key={stage} className="inline-flex items-center gap-1.5">
+              <span className="inline-block h-2 w-2 rounded-full" style={{ background: STAGE_COLORS[stage] }} />
+              {STAGE_LABELS[stage]}
+            </span>
+          ))}
+        </div>
+
+        <ResponsiveContainer width="100%" height={160}>
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+            <XAxis
+              dataKey="ts"
+              type="number"
+              domain={['dataMin', 'dataMax']}
+              scale="time"
+              tick={{ fill: '#94a3b8', fontSize: 11 }}
+              tickFormatter={fmtTs}
+              tickCount={8}
+            />
+            <YAxis
+              domain={[0.5, 4.5]}
+              ticks={[1, 2, 3, 4]}
+              tick={{ fill: '#94a3b8', fontSize: 11 }}
+              tickFormatter={v => STAGE_LABELS[v as number] ?? ''}
+              width={40}
+            />
+            <Tooltip
+              contentStyle={{ background: '#0f172a', border: '1px solid #334155', borderRadius: 12 }}
+              labelStyle={{ color: '#f8fafc' }}
+              labelFormatter={v => fmtTs(Number(v))}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              formatter={(val: any) => [STAGE_LABELS[val as number] ?? val, 'Stage']}
+            />
+            <Line
+              type="stepAfter"
+              dataKey="stage"
+              stroke="#94a3b8"
+              strokeWidth={1.5}
+              dot={<StageDot />}
+              activeDot={{ r: 4 }}
+              connectNulls={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/WearableVitalsChart.tsx
+++ b/frontend/src/components/WearableVitalsChart.tsx
@@ -1,0 +1,113 @@
+/**
+ * Heart rate + SpO2 chart.
+ *
+ * Both signals share the same time axis.  Heart rate uses the left Y-axis
+ * (bpm) and SpO2 uses the right Y-axis (%).  Either signal is omitted from
+ * the legend if no data for it exists in the sample set.
+ */
+
+import {
+  ComposedChart, Line, XAxis, YAxis, CartesianGrid,
+  Tooltip, Legend, ResponsiveContainer,
+} from 'recharts'
+import type { WearableSample } from '../api/client'
+import { getDisplayTz } from '../lib/displayTz'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+
+interface Props {
+  samples: WearableSample[]
+}
+
+function fmtTs(ts: number) {
+  return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: getDisplayTz() })
+}
+
+export default function WearableVitalsChart({ samples }: Props) {
+  const data = samples
+    .filter(s => s.heart_rate !== null || s.spo2 !== null)
+    .map(s => ({
+      ts:         new Date(s.ts).getTime(),
+      heart_rate: s.heart_rate,
+      spo2:       s.spo2,
+    }))
+
+  if (data.length === 0) return null
+
+  const hasHR   = data.some(d => d.heart_rate !== null)
+  const hasSpo2 = data.some(d => d.spo2 !== null)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Heart Rate &amp; SpO₂</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={240}>
+          <ComposedChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+            <XAxis
+              dataKey="ts"
+              type="number"
+              domain={['dataMin', 'dataMax']}
+              scale="time"
+              tick={{ fill: '#94a3b8', fontSize: 11 }}
+              tickFormatter={fmtTs}
+              tickCount={8}
+            />
+            {hasHR && (
+              <YAxis
+                yAxisId="hr"
+                domain={[30, 130]}
+                tick={{ fill: '#94a3b8', fontSize: 11 }}
+                label={{ value: 'bpm', angle: -90, position: 'insideLeft', fill: '#94a3b8', fontSize: 11 }}
+              />
+            )}
+            {hasSpo2 && (
+              <YAxis
+                yAxisId="spo2"
+                orientation="right"
+                domain={[85, 100]}
+                tick={{ fill: '#94a3b8', fontSize: 11 }}
+                label={{ value: 'SpO₂ %', angle: 90, position: 'insideRight', fill: '#94a3b8', fontSize: 11 }}
+              />
+            )}
+            <Tooltip
+              contentStyle={{ background: '#0f172a', border: '1px solid #334155', borderRadius: 12 }}
+              labelStyle={{ color: '#f8fafc' }}
+              labelFormatter={v => fmtTs(Number(v))}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              formatter={(val: any, name: any) => {
+                if (name === 'heart_rate') return [`${val} bpm`, 'Heart Rate']
+                if (name === 'spo2') return [`${val}%`, 'SpO₂']
+                return [String(val), String(name)]
+              }}
+            />
+            <Legend formatter={v => v === 'heart_rate' ? 'Heart Rate' : 'SpO₂'} />
+            {hasHR && (
+              <Line
+                yAxisId="hr"
+                type="monotone"
+                dataKey="heart_rate"
+                stroke="#f87171"
+                dot={false}
+                strokeWidth={1.5}
+                connectNulls={false}
+              />
+            )}
+            {hasSpo2 && (
+              <Line
+                yAxisId="spo2"
+                type="monotone"
+                dataKey="spo2"
+                stroke="#38bdf8"
+                dot={false}
+                strokeWidth={1.5}
+                connectNulls={false}
+              />
+            )}
+          </ComposedChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/lib/displayTz.ts
+++ b/frontend/src/lib/displayTz.ts
@@ -1,0 +1,15 @@
+/**
+ * Module-level display timezone singleton.
+ * Defaults to the browser's local timezone. Can be overridden by the
+ * server config (GET /config) on app startup.
+ */
+
+let _tz: string = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+export function getDisplayTz(): string {
+  return _tz
+}
+
+export function setDisplayTz(tz: string): void {
+  _tz = tz
+}

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { api } from '../api/client'
-import type { SessionDetail as SessionDetailType, EventRecord, MetricsResponse } from '../api/client'
+import type { SessionDetail as SessionDetailType, EventRecord, MetricsResponse, WearableSample } from '../api/client'
 import { ChevronLeftIcon, ChevronRightIcon } from '../components/icons/ChevronIcons'
 import EventTimeline from '../components/EventTimeline'
 import InfoPopover from '../components/InfoPopover'
 import MetricsChart from '../components/MetricsChart'
+import SleepStageChart from '../components/SleepStageChart'
+import WearableVitalsChart from '../components/WearableVitalsChart'
 import SessionAICard from '../components/SessionAICard'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
@@ -35,6 +37,7 @@ export default function SessionDetail() {
   const [session, setSession] = useState<SessionDetailType | null>(null)
   const [events, setEvents] = useState<EventRecord[]>([])
   const [metrics, setMetrics] = useState<MetricsResponse | null>(null)
+  const [wearable, setWearable] = useState<WearableSample[]>([])
   const [loading, setLoading] = useState(true)
   const [prevNext, setPrevNext] = useState<{ prev: string | null; next: string | null }>({ prev: null, next: null })
 
@@ -49,6 +52,8 @@ export default function SessionDetail() {
       setEvents(e)
       setMetrics(m)
       setLoading(false)
+      // Fetch wearable data for this session's date (non-blocking — chart is optional)
+      api.getWearableSamples(s.folder_date).then(r => setWearable(r.samples)).catch(() => {})
     }).catch(() => navigate('/dashboard'))
   }, [navigate, sessionId])
 
@@ -225,6 +230,9 @@ export default function SessionDetail() {
       </Card>
 
       <MetricsChart metrics={metrics} />
+
+      <WearableVitalsChart samples={wearable} />
+      <SleepStageChart samples={wearable} />
     </div>
   )
 }

--- a/migrations/007_add_wearable_samples.sql
+++ b/migrations/007_add_wearable_samples.sql
@@ -1,0 +1,34 @@
+BEGIN;
+
+-- Per-user wearable time-series data: heart rate, SpO2, and sleep stages
+-- from any external device (Withings, Oura Ring, Fitbit, Apple Watch, etc.).
+--
+-- Sleep stage encoding (matches conventional hypnogram orientation):
+--   1 = Deep   (N3 / SWS / slow-wave)
+--   2 = Light  (N1 / N2 / Core / unspecified asleep)
+--   3 = REM
+--   4 = Awake  (in-bed but awake)
+--
+-- raw_stage preserves the original label from the source device for auditability.
+-- Multiple rows for the same user+ts can exist if they come from different sources.
+
+CREATE TABLE wearable_samples (
+    id          BIGSERIAL PRIMARY KEY,
+    user_id     UUID      NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    ts          TIMESTAMPTZ NOT NULL,
+    heart_rate  SMALLINT,           -- bpm
+    spo2        NUMERIC(5,2),       -- % (0–100)
+    sleep_stage SMALLINT            -- 1=deep, 2=light, 3=rem, 4=awake
+        CHECK (sleep_stage BETWEEN 1 AND 4),
+    raw_stage   TEXT,               -- original label from the device
+    source      TEXT                -- 'withings' | 'oura' | 'fitbit' | 'apple_health'
+);
+
+-- Fast range queries by user + time
+CREATE INDEX idx_wearable_user_ts ON wearable_samples (user_id, ts);
+
+-- Upsert key: one row per user × timestamp × source
+CREATE UNIQUE INDEX uq_wearable_user_ts_source
+    ON wearable_samples (user_id, ts, source);
+
+COMMIT;


### PR DESCRIPTION
  **Summary**

  - New wearable_samples table stores heart rate, SpO₂, and sleep stages per user per timestamp, with a unique constraint on (user_id, ts, source) for idempotent upserts
  - Sleep stage normalisation maps device-specific label strings from Withings, Oura Ring, Fitbit, and Apple Watch to a shared integer encoding (1=Deep  2=Light  3=REM  4=Awake)
  - POST /wearable/samples accepts bulk JSON payloads with any mix of the four devices' stage naming conventions
  - GET /wearable/samples?date= returns all samples for a calendar date, including a 36-hour window to cover sessions that span midnight
  - Heart Rate & SpO₂ chart — dual-axis Recharts line chart added to session detail; silently absent if no wearable data exists for that date
  - Sleep stage hypnogram — step chart (type="stepAfter") with discrete Y-axis ticks and per-stage colour coding; follows conventional hypnogram orientation (deep at bottom, awake at top)

  **Test plan**

  - POST /wearable/samples with Withings, Oura, Fitbit, and Apple stage labels all parse to correct numeric values
  - Re-posting the same batch is idempotent (no duplicates)
  - GET /wearable/samples?date=2025-01-15 returns samples from both that date and the early hours of the 16th
  - Session detail page shows both charts when samples exist for the date
  - Session detail page shows neither chart when no wearable data exists (no empty card rendered)
  - Unknown stage label stored as NULL in sleep_stage, preserved in raw_stage