### PR TITLE
fix: aggregate multi-block sessions and improve Night Metrics chart

### DIFF
--- a/api/routers/sessions.py
+++ b/api/routers/sessions.py
@@ -34,13 +34,39 @@ def list_sessions(
     where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
 
     sql = text(f"""
-        SELECT id::text AS id, session_id, folder_date, block_index, start_datetime, duration_seconds,
+        WITH night AS (
+            SELECT
+                folder_date,
+                (array_agg(id::text ORDER BY duration_seconds DESC))[1] AS id,
+                (array_agg(session_id ORDER BY duration_seconds DESC))[1] AS session_id,
+                MIN(start_datetime) AS start_datetime,
+                0 AS block_index,
+                SUM(duration_seconds) AS duration_seconds,
+                SUM(total_ahi_events) AS total_ahi_events,
+                SUM(central_apnea_count) AS central_apnea_count,
+                SUM(obstructive_apnea_count) AS obstructive_apnea_count,
+                SUM(hypopnea_count) AS hypopnea_count,
+                SUM(apnea_count) AS apnea_count,
+                SUM(arousal_count) AS arousal_count,
+                AVG(avg_pressure) AS avg_pressure,
+                MAX(p95_pressure) AS p95_pressure,
+                AVG(avg_leak) AS avg_leak,
+                BOOL_OR(has_spo2) AS has_spo2,
+                CASE
+                    WHEN SUM(duration_seconds) > 0
+                    THEN ROUND((SUM(total_ahi_events) / (SUM(duration_seconds) / 3600.0))::numeric, 2)
+                    ELSE 0
+                END AS ahi
+            FROM sessions
+            {where}
+            GROUP BY folder_date
+        )
+        SELECT id, session_id, folder_date, block_index, start_datetime, duration_seconds,
                ahi, central_apnea_count, obstructive_apnea_count, hypopnea_count,
                apnea_count, arousal_count, total_ahi_events,
                avg_pressure, p95_pressure, avg_leak, has_spo2
-        FROM sessions
-        {where}
-        ORDER BY folder_date DESC, block_index ASC
+        FROM night
+        ORDER BY folder_date DESC
         LIMIT :limit OFFSET :offset
     """)
     rows = db.execute(sql, params).mappings().all()
@@ -53,14 +79,47 @@ def get_session(
     current_user: dict = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Full session detail."""
+    """Full session detail — aggregated across all blocks for the night."""
     row = db.execute(
-        text("SELECT id::text AS id, session_id, folder_date, block_index, start_datetime, "
-             "duration_seconds, ahi, central_apnea_count, obstructive_apnea_count, hypopnea_count, "
-             "apnea_count, arousal_count, total_ahi_events, avg_pressure, p95_pressure, avg_leak, has_spo2, "
-             "pld_start_datetime, device_serial, avg_resp_rate, avg_tidal_vol, avg_min_vent, avg_snore, "
-             "avg_flow_lim, avg_spo2, min_spo2 "
-             "FROM sessions WHERE id = CAST(:id AS uuid) AND user_id = CAST(:uid AS uuid)"),
+        text("""
+            WITH night AS (
+                SELECT folder_date, user_id
+                FROM sessions
+                WHERE id = CAST(:id AS uuid) AND user_id = CAST(:uid AS uuid)
+            )
+            SELECT
+                (array_agg(s.id::text ORDER BY s.duration_seconds DESC))[1] AS id,
+                (array_agg(s.session_id ORDER BY s.duration_seconds DESC))[1] AS session_id,
+                s.folder_date,
+                0 AS block_index,
+                MIN(s.start_datetime) AS start_datetime,
+                MIN(s.start_datetime) AS pld_start_datetime,
+                SUM(s.duration_seconds) AS duration_seconds,
+                SUM(s.total_ahi_events) AS total_ahi_events,
+                SUM(s.central_apnea_count) AS central_apnea_count,
+                SUM(s.obstructive_apnea_count) AS obstructive_apnea_count,
+                SUM(s.hypopnea_count) AS hypopnea_count,
+                SUM(s.apnea_count) AS apnea_count,
+                SUM(s.arousal_count) AS arousal_count,
+                AVG(s.avg_pressure) AS avg_pressure,
+                MAX(s.p95_pressure) AS p95_pressure,
+                AVG(s.avg_leak) AS avg_leak,
+                BOOL_OR(s.has_spo2) AS has_spo2,
+                CASE WHEN SUM(s.duration_seconds) > 0
+                     THEN ROUND((SUM(s.total_ahi_events) / (SUM(s.duration_seconds) / 3600.0))::numeric, 2)
+                     ELSE 0 END AS ahi,
+                AVG(s.avg_resp_rate) AS avg_resp_rate,
+                AVG(s.avg_tidal_vol) AS avg_tidal_vol,
+                AVG(s.avg_min_vent) AS avg_min_vent,
+                AVG(s.avg_snore) AS avg_snore,
+                AVG(s.avg_flow_lim) AS avg_flow_lim,
+                AVG(s.avg_spo2) AS avg_spo2,
+                MIN(s.min_spo2) AS min_spo2,
+                (array_agg(s.device_serial ORDER BY s.duration_seconds DESC))[1] AS device_serial
+            FROM sessions s
+            JOIN night n ON s.folder_date = n.folder_date AND s.user_id = n.user_id
+            GROUP BY s.folder_date
+        """),
         {"id": session_id, "uid": current_user["id"]},
     ).mappings().first()
     if not row:
@@ -78,12 +137,14 @@ def get_session_events(
     internal_session_id = _require_session(session_id, current_user["id"], db)
     rows = db.execute(
         text("""
-            SELECT id, event_type, onset_seconds, duration_seconds, event_datetime
-            FROM session_events
-            WHERE session_id = :sid
-            ORDER BY onset_seconds
+            SELECT se.id, se.event_type, se.onset_seconds, se.duration_seconds, se.event_datetime
+            FROM session_events se
+            JOIN sessions s ON se.session_id = s.id
+            WHERE s.folder_date = (SELECT folder_date FROM sessions WHERE id = CAST(:sid AS uuid))
+              AND s.user_id = CAST(:uid AS uuid)
+            ORDER BY se.event_datetime
         """),
-        {"sid": internal_session_id}
+        {"sid": internal_session_id, "uid": current_user["id"]}
     ).mappings().all()
     return [EventRecord.model_validate(dict(r)) for r in rows]
 
@@ -108,8 +169,10 @@ def get_session_metrics(
                 SELECT ts, mask_pressure, pressure, epr_pressure, leak,
                        resp_rate, tidal_vol, min_vent, snore, flow_lim,
                        ROW_NUMBER() OVER (ORDER BY ts) AS rn
-                FROM session_metrics
-                WHERE session_id = :sid
+                FROM session_metrics sm
+                JOIN sessions s ON sm.session_id = s.id
+                WHERE s.folder_date = (SELECT folder_date FROM sessions WHERE id = CAST(:sid AS uuid))
+                  AND s.user_id = CAST(:uid AS uuid)
             )
             SELECT ts, mask_pressure, pressure, epr_pressure, leak,
                    resp_rate, tidal_vol, min_vent, snore, flow_lim
@@ -117,7 +180,7 @@ def get_session_metrics(
             WHERE rn % :ds = 1
             ORDER BY ts
         """),
-        {"sid": internal_session_id, "ds": downsample}
+        {"sid": internal_session_id, "ds": downsample, "uid": current_user["id"]}
     ).mappings().all()
 
     if not rows:

--- a/api/routers/sessions.py
+++ b/api/routers/sessions.py
@@ -59,6 +59,7 @@ def list_sessions(
                 END AS ahi
             FROM sessions
             {where}
+            {"AND" if where else "WHERE"} duration_seconds >= 600
             GROUP BY folder_date
         )
         SELECT id, session_id, folder_date, block_index, start_datetime, duration_seconds,
@@ -118,6 +119,7 @@ def get_session(
                 (array_agg(s.device_serial ORDER BY s.duration_seconds DESC))[1] AS device_serial
             FROM sessions s
             JOIN night n ON s.folder_date = n.folder_date AND s.user_id = n.user_id
+            WHERE s.duration_seconds >= 600
             GROUP BY s.folder_date
         """),
         {"id": session_id, "uid": current_user["id"]},

--- a/frontend/src/components/MetricsChart.tsx
+++ b/frontend/src/components/MetricsChart.tsx
@@ -64,7 +64,20 @@ export default function MetricsChart({ metrics }: Props) {
             <YAxis
               yAxisId="pressure"
               tick={{ fill: '#94a3b8', fontSize: 11 }}
-              domain={[Math.max(0, Math.min(...data.filter(d => d.pressure !== null).map(d => d.pressure as number)) - 2), 20]}
+              domain={(() => {
+                const vals = data.filter(d => d.pressure !== null).map(d => d.pressure as number)
+                const lo = vals.length > 0 ? Math.floor(Math.min(...vals)) - 2 : 2
+                const hi = vals.length > 0 ? Math.ceil(Math.max(...vals)) + 2 : 20
+                return [Math.max(0, lo), hi]
+              })()}
+              ticks={(() => {
+                const vals = data.filter(d => d.pressure !== null).map(d => d.pressure as number)
+                const lo = vals.length > 0 ? Math.floor(Math.min(...vals)) - 2 : 2
+                const hi = vals.length > 0 ? Math.ceil(Math.max(...vals)) + 2 : 20
+                const result = []
+                for (let i = Math.max(0, lo); i <= hi; i += 2) result.push(i)
+                return result
+              })()}
               label={{ value: 'cmH₂O', angle: -90, position: 'insideLeft', fill: '#94a3b8', fontSize: 11 }}
             />
             <YAxis

--- a/frontend/src/components/MetricsChart.tsx
+++ b/frontend/src/components/MetricsChart.tsx
@@ -63,7 +63,7 @@ export default function MetricsChart({ metrics }: Props) {
             <YAxis
               yAxisId="pressure"
               tick={{ fill: '#94a3b8', fontSize: 11 }}
-              domain={[4, 20]}
+              domain={[Math.max(0, Math.min(...data.filter(d => d.pressure !== null).map(d => d.pressure as number)) - 2), 20]}
               label={{ value: 'cmH₂O', angle: -90, position: 'insideLeft', fill: '#94a3b8', fontSize: 11 }}
             />
             <YAxis

--- a/frontend/src/components/MetricsChart.tsx
+++ b/frontend/src/components/MetricsChart.tsx
@@ -10,13 +10,33 @@ interface Props {
 }
 
 export default function MetricsChart({ metrics }: Props) {
-  const data = metrics.timestamps.map((ts, i) => ({
+  const GAP_THRESHOLD_MS = 5 * 60 * 1000 // 5 minutes
+  const rawData = metrics.timestamps.map((ts, i) => ({
     ts: new Date(ts).getTime(),
     pressure: metrics.pressure[i],
     leak: metrics.leak[i],
     resp_rate: metrics.resp_rate[i],
     flow_lim: metrics.flow_lim[i],
   }))
+  const MIN_PRESSURE = 4.0
+  const data: typeof rawData = []
+  let inGap = false
+  for (let i = 0; i < rawData.length; i++) {
+    const isGap = i > 0 && rawData[i].ts - rawData[i - 1].ts > GAP_THRESHOLD_MS
+    if (isGap) {
+      data.push({ ts: rawData[i - 1].ts + 1, pressure: null as any, leak: null as any, resp_rate: null as any, flow_lim: null as any })
+      inGap = true
+    }
+    // Skip leading ramp-up points at minimum pressure after a gap
+    if (inGap && rawData[i].pressure !== null && (rawData[i].pressure ?? 0) <= MIN_PRESSURE) {
+      continue
+    }
+    if (inGap && rawData[i].pressure !== null && (rawData[i].pressure ?? 0) > MIN_PRESSURE) {
+      data.push({ ts: rawData[i].ts - 1, pressure: null as any, leak: null as any, resp_rate: null as any, flow_lim: null as any })
+      inGap = false
+    }
+    data.push(rawData[i])
+  }
 
   function fmtTs(ts: number) {
     return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })

--- a/frontend/src/components/MetricsChart.tsx
+++ b/frontend/src/components/MetricsChart.tsx
@@ -18,7 +18,8 @@ export default function MetricsChart({ metrics }: Props) {
     resp_rate: metrics.resp_rate[i],
     flow_lim: metrics.flow_lim[i],
   }))
-  const MIN_PRESSURE = 4.0
+  const pressureVals = rawData.map(d => d.pressure).filter((p): p is number => p !== null && p > 0)
+  const MIN_PRESSURE = pressureVals.length > 0 ? Math.min(...pressureVals) : 4.0
   const data: typeof rawData = []
   let inGap = false
   for (let i = 0; i < rawData.length; i++) {

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -56,7 +56,7 @@ export default function SessionDetail() {
     if (!session) return
     api.getSessions({ per_page: 600 }).then(all => {
       const sorted = all
-        .filter(s => s.block_index === 0)
+        
         .sort((a, b) => a.folder_date.localeCompare(b.folder_date))
       const idx = sorted.findIndex(s => s.id === sessionId)
       setPrevNext({


### PR DESCRIPTION
Nights where the mask is removed and replaced create multiple PLD recording blocks. This fixes the dashboard to show the full night correctly.

**Changes:**
- Aggregate all blocks per night in both list and detail API endpoints (combined duration, weighted AHI, summed events)
- Exclude blocks under 10 minutes from aggregation (mask-on test moments that skew AHI)
- Break the Night Metrics chart line at mask-off gaps instead of drawing through them
- Dynamic pressure Y-axis minimum set to data min minus 2, mimicking SleepHQ's presentation

**Validated against SleepHQ** — AHI, pressure, and usage now match within rounding for multiple nights tested on a ResMed AirSense 10.