### PR TITLE
feat: split Night Metrics chart into separate panels per metric

### DIFF
--- a/api/routers/sessions.py
+++ b/api/routers/sessions.py
@@ -302,3 +302,16 @@ def _require_session(session_id: str, user_id: str, db: Session) -> str:
 def _f(val) -> Optional[float]:
     """Convert Decimal to float for JSON serialization."""
     return float(val) if val is not None else None
+
+
+@router.delete("/all", status_code=204)
+def delete_all_sessions(
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Delete all session data for the current user."""
+    db.execute(
+        text("DELETE FROM sessions WHERE user_id = CAST(:uid AS uuid)"),
+        {"uid": current_user["id"]},
+    )
+    db.commit()

--- a/api/routers/sessions.py
+++ b/api/routers/sessions.py
@@ -34,13 +34,40 @@ def list_sessions(
     where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
 
     sql = text(f"""
-        SELECT id::text AS id, session_id, folder_date, block_index, start_datetime, duration_seconds,
+        WITH night AS (
+            SELECT
+                folder_date,
+                (array_agg(id::text ORDER BY duration_seconds DESC))[1] AS id,
+                (array_agg(session_id ORDER BY duration_seconds DESC))[1] AS session_id,
+                MIN(start_datetime) AS start_datetime,
+                0 AS block_index,
+                SUM(duration_seconds) AS duration_seconds,
+                SUM(total_ahi_events) AS total_ahi_events,
+                SUM(central_apnea_count) AS central_apnea_count,
+                SUM(obstructive_apnea_count) AS obstructive_apnea_count,
+                SUM(hypopnea_count) AS hypopnea_count,
+                SUM(apnea_count) AS apnea_count,
+                SUM(arousal_count) AS arousal_count,
+                AVG(avg_pressure) AS avg_pressure,
+                MAX(p95_pressure) AS p95_pressure,
+                AVG(avg_leak) AS avg_leak,
+                BOOL_OR(has_spo2) AS has_spo2,
+                CASE
+                    WHEN SUM(duration_seconds) > 0
+                    THEN ROUND((SUM(total_ahi_events) / (SUM(duration_seconds) / 3600.0))::numeric, 2)
+                    ELSE 0
+                END AS ahi
+            FROM sessions
+            {where}
+            {"AND" if where else "WHERE"} duration_seconds >= 600
+            GROUP BY folder_date
+        )
+        SELECT id, session_id, folder_date, block_index, start_datetime, duration_seconds,
                ahi, central_apnea_count, obstructive_apnea_count, hypopnea_count,
                apnea_count, arousal_count, total_ahi_events,
                avg_pressure, p95_pressure, avg_leak, has_spo2
-        FROM sessions
-        {where}
-        ORDER BY folder_date DESC, block_index ASC
+        FROM night
+        ORDER BY folder_date DESC
         LIMIT :limit OFFSET :offset
     """)
     rows = db.execute(sql, params).mappings().all()
@@ -53,14 +80,48 @@ def get_session(
     current_user: dict = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Full session detail."""
+    """Full session detail — aggregated across all blocks for the night."""
     row = db.execute(
-        text("SELECT id::text AS id, session_id, folder_date, block_index, start_datetime, "
-             "duration_seconds, ahi, central_apnea_count, obstructive_apnea_count, hypopnea_count, "
-             "apnea_count, arousal_count, total_ahi_events, avg_pressure, p95_pressure, avg_leak, has_spo2, "
-             "pld_start_datetime, device_serial, avg_resp_rate, avg_tidal_vol, avg_min_vent, avg_snore, "
-             "avg_flow_lim, avg_spo2, min_spo2 "
-             "FROM sessions WHERE id = CAST(:id AS uuid) AND user_id = CAST(:uid AS uuid)"),
+        text("""
+            WITH night AS (
+                SELECT folder_date, user_id
+                FROM sessions
+                WHERE id = CAST(:id AS uuid) AND user_id = CAST(:uid AS uuid)
+            )
+            SELECT
+                (array_agg(s.id::text ORDER BY s.duration_seconds DESC))[1] AS id,
+                (array_agg(s.session_id ORDER BY s.duration_seconds DESC))[1] AS session_id,
+                s.folder_date,
+                0 AS block_index,
+                MIN(s.start_datetime) AS start_datetime,
+                MIN(s.start_datetime) AS pld_start_datetime,
+                SUM(s.duration_seconds) AS duration_seconds,
+                SUM(s.total_ahi_events) AS total_ahi_events,
+                SUM(s.central_apnea_count) AS central_apnea_count,
+                SUM(s.obstructive_apnea_count) AS obstructive_apnea_count,
+                SUM(s.hypopnea_count) AS hypopnea_count,
+                SUM(s.apnea_count) AS apnea_count,
+                SUM(s.arousal_count) AS arousal_count,
+                AVG(s.avg_pressure) AS avg_pressure,
+                MAX(s.p95_pressure) AS p95_pressure,
+                AVG(s.avg_leak) AS avg_leak,
+                BOOL_OR(s.has_spo2) AS has_spo2,
+                CASE WHEN SUM(s.duration_seconds) > 0
+                     THEN ROUND((SUM(s.total_ahi_events) / (SUM(s.duration_seconds) / 3600.0))::numeric, 2)
+                     ELSE 0 END AS ahi,
+                AVG(s.avg_resp_rate) AS avg_resp_rate,
+                AVG(s.avg_tidal_vol) AS avg_tidal_vol,
+                AVG(s.avg_min_vent) AS avg_min_vent,
+                AVG(s.avg_snore) AS avg_snore,
+                AVG(s.avg_flow_lim) AS avg_flow_lim,
+                AVG(s.avg_spo2) AS avg_spo2,
+                MIN(s.min_spo2) AS min_spo2,
+                (array_agg(s.device_serial ORDER BY s.duration_seconds DESC))[1] AS device_serial
+            FROM sessions s
+            JOIN night n ON s.folder_date = n.folder_date AND s.user_id = n.user_id
+            WHERE s.duration_seconds >= 600
+            GROUP BY s.folder_date
+        """),
         {"id": session_id, "uid": current_user["id"]},
     ).mappings().first()
     if not row:
@@ -78,12 +139,14 @@ def get_session_events(
     internal_session_id = _require_session(session_id, current_user["id"], db)
     rows = db.execute(
         text("""
-            SELECT id, event_type, onset_seconds, duration_seconds, event_datetime
-            FROM session_events
-            WHERE session_id = :sid
-            ORDER BY onset_seconds
+            SELECT se.id, se.event_type, se.onset_seconds, se.duration_seconds, se.event_datetime
+            FROM session_events se
+            JOIN sessions s ON se.session_id = s.id
+            WHERE s.folder_date = (SELECT folder_date FROM sessions WHERE id = CAST(:sid AS uuid))
+              AND s.user_id = CAST(:uid AS uuid)
+            ORDER BY se.event_datetime
         """),
-        {"sid": internal_session_id}
+        {"sid": internal_session_id, "uid": current_user["id"]}
     ).mappings().all()
     return [EventRecord.model_validate(dict(r)) for r in rows]
 
@@ -108,8 +171,10 @@ def get_session_metrics(
                 SELECT ts, mask_pressure, pressure, epr_pressure, leak,
                        resp_rate, tidal_vol, min_vent, snore, flow_lim,
                        ROW_NUMBER() OVER (ORDER BY ts) AS rn
-                FROM session_metrics
-                WHERE session_id = :sid
+                FROM session_metrics sm
+                JOIN sessions s ON sm.session_id = s.id
+                WHERE s.folder_date = (SELECT folder_date FROM sessions WHERE id = CAST(:sid AS uuid))
+                  AND s.user_id = CAST(:uid AS uuid)
             )
             SELECT ts, mask_pressure, pressure, epr_pressure, leak,
                    resp_rate, tidal_vol, min_vent, snore, flow_lim
@@ -117,7 +182,7 @@ def get_session_metrics(
             WHERE rn % :ds = 1
             ORDER BY ts
         """),
-        {"sid": internal_session_id, "ds": downsample}
+        {"sid": internal_session_id, "ds": downsample, "uid": current_user["id"]}
     ).mappings().all()
 
     if not rows:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -258,6 +258,7 @@ export const api = {
   me: () => get<AuthUser>('/auth/me'),
   updateProfile: (payload: UpdateProfileRequest) => put<AuthUser>('/auth/profile', payload),
   changePassword: (payload: ChangePasswordRequest) => put<{ status: string }>('/auth/password', payload),
+  deleteAllSessions: () => request<void>('/sessions/all', { method: 'DELETE' }),
   startImportUpload: (rootName: string, fromDate?: string) =>
     post<StartImportResponse>('/upload/datalog/start', {
       root_name: rootName,

--- a/frontend/src/components/MetricsChart.tsx
+++ b/frontend/src/components/MetricsChart.tsx
@@ -10,13 +10,34 @@ interface Props {
 }
 
 export default function MetricsChart({ metrics }: Props) {
-  const data = metrics.timestamps.map((ts, i) => ({
+  const GAP_THRESHOLD_MS = 5 * 60 * 1000 // 5 minutes
+  const rawData = metrics.timestamps.map((ts, i) => ({
     ts: new Date(ts).getTime(),
     pressure: metrics.pressure[i],
     leak: metrics.leak[i],
     resp_rate: metrics.resp_rate[i],
     flow_lim: metrics.flow_lim[i],
   }))
+  const pressureVals = rawData.map(d => d.pressure).filter((p): p is number => p !== null && p > 0)
+  const MIN_PRESSURE = pressureVals.length > 0 ? Math.min(...pressureVals) : 4.0
+  const data: typeof rawData = []
+  let inGap = false
+  for (let i = 0; i < rawData.length; i++) {
+    const isGap = i > 0 && rawData[i].ts - rawData[i - 1].ts > GAP_THRESHOLD_MS
+    if (isGap) {
+      data.push({ ts: rawData[i - 1].ts + 1, pressure: null as any, leak: null as any, resp_rate: null as any, flow_lim: null as any })
+      inGap = true
+    }
+    // Skip leading ramp-up points at minimum pressure after a gap
+    if (inGap && rawData[i].pressure !== null && (rawData[i].pressure ?? 0) <= MIN_PRESSURE) {
+      continue
+    }
+    if (inGap && rawData[i].pressure !== null && (rawData[i].pressure ?? 0) > MIN_PRESSURE) {
+      data.push({ ts: rawData[i].ts - 1, pressure: null as any, leak: null as any, resp_rate: null as any, flow_lim: null as any })
+      inGap = false
+    }
+    data.push(rawData[i])
+  }
 
   function fmtTs(ts: number) {
     return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
@@ -43,7 +64,20 @@ export default function MetricsChart({ metrics }: Props) {
             <YAxis
               yAxisId="pressure"
               tick={{ fill: '#94a3b8', fontSize: 11 }}
-              domain={[4, 20]}
+              domain={(() => {
+                const vals = data.filter(d => d.pressure !== null).map(d => d.pressure as number)
+                const lo = vals.length > 0 ? Math.floor(Math.min(...vals)) - 2 : 2
+                const hi = vals.length > 0 ? Math.ceil(Math.max(...vals)) + 2 : 20
+                return [Math.max(0, lo), hi]
+              })()}
+              ticks={(() => {
+                const vals = data.filter(d => d.pressure !== null).map(d => d.pressure as number)
+                const lo = vals.length > 0 ? Math.floor(Math.min(...vals)) - 2 : 2
+                const hi = vals.length > 0 ? Math.ceil(Math.max(...vals)) + 2 : 20
+                const result = []
+                for (let i = Math.max(0, lo); i <= hi; i += 2) result.push(i)
+                return result
+              })()}
               label={{ value: 'cmH₂O', angle: -90, position: 'insideLeft', fill: '#94a3b8', fontSize: 11 }}
             />
             <YAxis

--- a/frontend/src/components/MetricsChartSplit.tsx
+++ b/frontend/src/components/MetricsChartSplit.tsx
@@ -1,0 +1,141 @@
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip,
+  ResponsiveContainer
+} from 'recharts'
+import type { MetricsResponse } from '../api/client'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+
+interface Props {
+  metrics: MetricsResponse
+}
+
+export default function MetricsChartSplit({ metrics }: Props) {
+  const GAP_THRESHOLD_MS = 5 * 60 * 1000
+
+  const rawData = metrics.timestamps.map((ts, i) => ({
+    ts: new Date(ts).getTime(),
+    pressure: metrics.pressure[i],
+    leak: metrics.leak[i],
+    resp_rate: metrics.resp_rate[i],
+    flow_lim: metrics.flow_lim[i],
+  }))
+
+  const pressureVals = rawData.map(d => d.pressure).filter((p): p is number => p !== null && p > 0)
+  const MIN_PRESSURE = pressureVals.length > 0 ? Math.min(...pressureVals) : 4.0
+
+  const data: typeof rawData = []
+  let inGap = false
+  for (let i = 0; i < rawData.length; i++) {
+    const isGap = i > 0 && rawData[i].ts - rawData[i - 1].ts > GAP_THRESHOLD_MS
+    if (isGap) {
+      data.push({ ts: rawData[i - 1].ts + 1, pressure: null as any, leak: null as any, resp_rate: null as any, flow_lim: null as any })
+      inGap = true
+    }
+    if (inGap && rawData[i].pressure !== null && (rawData[i].pressure ?? 0) <= MIN_PRESSURE) continue
+    if (inGap && rawData[i].pressure !== null && (rawData[i].pressure ?? 0) > MIN_PRESSURE) {
+      data.push({ ts: rawData[i].ts - 1, pressure: null as any, leak: null as any, resp_rate: null as any, flow_lim: null as any })
+      inGap = false
+    }
+    data.push(rawData[i])
+  }
+
+  function fmtTs(ts: number) {
+    return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  }
+
+  // Generate ticks every 30 minutes across the data range
+  const TICK_INTERVAL_MS = 30 * 60 * 1000
+  const tsValues = data.map(d => d.ts).filter(t => t != null)
+  const minTs = tsValues.length > 0 ? Math.min(...tsValues) : 0
+  const maxTs = tsValues.length > 0 ? Math.max(...tsValues) : 0
+  const xTicks: number[] = []
+  const firstTick = Math.ceil(minTs / TICK_INTERVAL_MS) * TICK_INTERVAL_MS
+  for (let t = firstTick; t <= maxTs; t += TICK_INTERVAL_MS) {
+    xTicks.push(t)
+  }
+
+  const pressVals = data.filter(d => d.pressure !== null).map(d => d.pressure as number)
+  const pressLo = pressVals.length > 0 ? Math.max(0, Math.floor(Math.min(...pressVals)) - 2) : 2
+  const pressHi = pressVals.length > 0 ? Math.ceil(Math.max(...pressVals)) + 2 : 20
+  const pressTicks = []
+  for (let i = pressLo; i <= pressHi; i += 2) pressTicks.push(i)
+
+  const commonXAxis = (
+    <XAxis dataKey="ts" type="number" domain={['dataMin', 'dataMax']} scale="time"
+      tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={fmtTs} ticks={xTicks} />
+  )
+
+  const commonProps = {
+    data,
+    margin: { top: 4, right: 16, left: 0, bottom: 0 }
+  }
+
+  const panels = [
+    {
+      title: 'Pressure',
+      dataKey: 'pressure',
+      stroke: '#38bdf8',
+      unit: 'cmH₂O',
+      domain: [pressLo, pressHi] as [number, number],
+      ticks: pressTicks,
+    },
+    {
+      title: 'Resp Rate',
+      dataKey: 'resp_rate',
+      stroke: '#4ade80',
+      unit: 'bpm',
+      domain: [0, 40] as [number, number],
+      ticks: [0, 10, 20, 30, 40],
+    },
+    {
+      title: 'Leak',
+      dataKey: 'leak',
+      stroke: '#fb923c',
+      unit: 'L/s',
+      domain: [0, 'auto'] as [number, string],
+      ticks: undefined,
+    },
+    {
+      title: 'Flow Limitation',
+      dataKey: 'flow_lim',
+      stroke: '#f472b6',
+      unit: '',
+      domain: [0, 'auto'] as [number, string],
+      ticks: undefined,
+    },
+  ]
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Night Metrics</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {panels.map((panel) => (
+          <div key={panel.dataKey}>
+            <p className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--muted-foreground)] mb-1">{panel.title}{panel.unit ? ` (${panel.unit})` : ''}</p>
+            <ResponsiveContainer width="100%" height={120}>
+              <LineChart {...commonProps}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+                {commonXAxis}
+                <YAxis
+                  tick={{ fill: '#94a3b8', fontSize: 11 }}
+                  domain={panel.domain}
+                  ticks={panel.ticks}
+                  width={32}
+                />
+                <Tooltip
+                  contentStyle={{ background: '#0f172a', border: '1px solid #334155', borderRadius: 12 }}
+                  labelStyle={{ color: '#f8fafc' }}
+                  labelFormatter={(v) => fmtTs(Number(v))}
+                  formatter={(val: number | undefined) => [val != null ? `${val.toFixed(2)} ${panel.unit}` : 'N/A', panel.title]}
+                />
+                <Line type="monotone" dataKey={panel.dataKey} stroke={panel.stroke} dot={false} strokeWidth={1.5} connectNulls={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/components/MetricsChartSplit.tsx
+++ b/frontend/src/components/MetricsChartSplit.tsx
@@ -15,9 +15,11 @@ export default function MetricsChartSplit({ metrics }: Props) {
   const rawData = metrics.timestamps.map((ts, i) => ({
     ts: new Date(ts).getTime(),
     pressure: metrics.pressure[i],
-    leak: metrics.leak[i],
+    leak: metrics.leak[i] != null ? metrics.leak[i]! * 1000 : null,
     resp_rate: metrics.resp_rate[i],
     flow_lim: metrics.flow_lim[i],
+    snore: metrics.snore[i],
+    min_vent: metrics.min_vent[i],
   }))
 
   const pressureVals = rawData.map(d => d.pressure).filter((p): p is number => p !== null && p > 0)
@@ -28,12 +30,12 @@ export default function MetricsChartSplit({ metrics }: Props) {
   for (let i = 0; i < rawData.length; i++) {
     const isGap = i > 0 && rawData[i].ts - rawData[i - 1].ts > GAP_THRESHOLD_MS
     if (isGap) {
-      data.push({ ts: rawData[i - 1].ts + 1, pressure: null as any, leak: null as any, resp_rate: null as any, flow_lim: null as any })
+      data.push({ ts: rawData[i - 1].ts + 1, pressure: null as any, leak: null as any, resp_rate: null as any, flow_lim: null as any, snore: null as any, min_vent: null as any })
       inGap = true
     }
     if (inGap && rawData[i].pressure !== null && (rawData[i].pressure ?? 0) <= MIN_PRESSURE) continue
     if (inGap && rawData[i].pressure !== null && (rawData[i].pressure ?? 0) > MIN_PRESSURE) {
-      data.push({ ts: rawData[i].ts - 1, pressure: null as any, leak: null as any, resp_rate: null as any, flow_lim: null as any })
+      data.push({ ts: rawData[i].ts - 1, pressure: null as any, leak: null as any, resp_rate: null as any, flow_lim: null as any, snore: null as any, min_vent: null as any })
       inGap = false
     }
     data.push(rawData[i])
@@ -43,67 +45,41 @@ export default function MetricsChartSplit({ metrics }: Props) {
     return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
   }
 
-  // Generate ticks every 30 minutes across the data range
   const TICK_INTERVAL_MS = 30 * 60 * 1000
   const tsValues = data.map(d => d.ts).filter(t => t != null)
   const minTs = tsValues.length > 0 ? Math.min(...tsValues) : 0
   const maxTs = tsValues.length > 0 ? Math.max(...tsValues) : 0
   const xTicks: number[] = []
   const firstTick = Math.ceil(minTs / TICK_INTERVAL_MS) * TICK_INTERVAL_MS
-  for (let t = firstTick; t <= maxTs; t += TICK_INTERVAL_MS) {
-    xTicks.push(t)
+  for (let t = firstTick; t <= maxTs; t += TICK_INTERVAL_MS) xTicks.push(t)
+
+  function makeTicks(dataKey: string, padding: number): { domain: [number, number], ticks: number[] } {
+    const vals = data
+      .map(d => (d as any)[dataKey] as number | null)
+      .filter((v): v is number => v !== null && !isNaN(v))
+    if (vals.length === 0) return { domain: [0, 10], ticks: [0, 2.5, 5, 7.5, 10] }
+    const lo = Math.max(0, Math.floor(Math.min(...vals)) - padding)
+    const hi = Math.ceil(Math.max(...vals)) + padding
+    const step = (hi - lo) / 4
+    const ticks = [0, 1, 2, 3, 4].map(i => Math.round((lo + i * step) * 100) / 100)
+    return { domain: [ticks[0], ticks[4]], ticks }
   }
 
-  const pressVals = data.filter(d => d.pressure !== null).map(d => d.pressure as number)
-  const pressLo = pressVals.length > 0 ? Math.max(0, Math.floor(Math.min(...pressVals)) - 2) : 2
-  const pressHi = pressVals.length > 0 ? Math.ceil(Math.max(...pressVals)) + 2 : 20
-  const pressTicks = []
-  for (let i = pressLo; i <= pressHi; i += 2) pressTicks.push(i)
+  const panels = [
+    { title: 'Pressure', dataKey: 'pressure', stroke: '#38bdf8', unit: 'cmH₂O', ...makeTicks('pressure', 1) },
+    { title: 'Resp Rate', dataKey: 'resp_rate', stroke: '#4ade80', unit: 'bpm', domain: [0, 40] as [number, number], ticks: [0, 10, 20, 30, 40] },
+    { title: 'Leak', dataKey: 'leak', stroke: '#fb923c', unit: 'mL/s', ...makeTicks('leak', 0) },
+    { title: 'Flow Limitation', dataKey: 'flow_lim', stroke: '#f472b6', unit: '', ...makeTicks('flow_lim', 0) },
+    { title: 'Snore', dataKey: 'snore', stroke: '#a78bfa', unit: '', ...makeTicks('snore', 0) },
+    { title: 'Min Ventilation', dataKey: 'min_vent', stroke: '#34d399', unit: 'L/min', ...makeTicks('min_vent', 1) },
+  ]
 
   const commonXAxis = (
     <XAxis dataKey="ts" type="number" domain={['dataMin', 'dataMax']} scale="time"
       tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={fmtTs} ticks={xTicks} />
   )
 
-  const commonProps = {
-    data,
-    margin: { top: 4, right: 16, left: 0, bottom: 0 }
-  }
-
-  const panels = [
-    {
-      title: 'Pressure',
-      dataKey: 'pressure',
-      stroke: '#38bdf8',
-      unit: 'cmH₂O',
-      domain: [pressLo, pressHi] as [number, number],
-      ticks: pressTicks,
-    },
-    {
-      title: 'Resp Rate',
-      dataKey: 'resp_rate',
-      stroke: '#4ade80',
-      unit: 'bpm',
-      domain: [0, 40] as [number, number],
-      ticks: [0, 10, 20, 30, 40],
-    },
-    {
-      title: 'Leak',
-      dataKey: 'leak',
-      stroke: '#fb923c',
-      unit: 'L/s',
-      domain: [0, 'auto'] as [number, string],
-      ticks: undefined,
-    },
-    {
-      title: 'Flow Limitation',
-      dataKey: 'flow_lim',
-      stroke: '#f472b6',
-      unit: '',
-      domain: [0, 'auto'] as [number, string],
-      ticks: undefined,
-    },
-  ]
+  const commonProps = { data, margin: { top: 4, right: 16, left: 0, bottom: 0 } }
 
   return (
     <Card>
@@ -113,8 +89,10 @@ export default function MetricsChartSplit({ metrics }: Props) {
       <CardContent className="space-y-4">
         {panels.map((panel) => (
           <div key={panel.dataKey}>
-            <p className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--muted-foreground)] mb-1">{panel.title}{panel.unit ? ` (${panel.unit})` : ''}</p>
-            <ResponsiveContainer width="100%" height={120}>
+            <p className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--muted-foreground)] mb-1">
+              {panel.title}{panel.unit ? ` (${panel.unit})` : ''}
+            </p>
+            <ResponsiveContainer width="100%" height={150}>
               <LineChart {...commonProps}>
                 <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
                 {commonXAxis}
@@ -122,13 +100,16 @@ export default function MetricsChartSplit({ metrics }: Props) {
                   tick={{ fill: '#94a3b8', fontSize: 11 }}
                   domain={panel.domain}
                   ticks={panel.ticks}
-                  width={32}
+                  width={36}
                 />
                 <Tooltip
                   contentStyle={{ background: '#0f172a', border: '1px solid #334155', borderRadius: 12 }}
                   labelStyle={{ color: '#f8fafc' }}
                   labelFormatter={(v) => fmtTs(Number(v))}
-                  formatter={(val: number | undefined) => [val != null ? `${val.toFixed(2)} ${panel.unit}` : 'N/A', panel.title]}
+                  formatter={(val: number | undefined) => [
+                    val != null ? `${val.toFixed(2)} ${panel.unit}` : 'N/A',
+                    panel.title
+                  ]}
                 />
                 <Line type="monotone" dataKey={panel.dataKey} stroke={panel.stroke} dot={false} strokeWidth={1.5} connectNulls={false} />
               </LineChart>

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -56,7 +56,7 @@ export default function SessionDetail() {
     if (!session) return
     api.getSessions({ per_page: 600 }).then(all => {
       const sorted = all
-        .filter(s => s.block_index === 0)
+        
         .sort((a, b) => a.folder_date.localeCompare(b.folder_date))
       const idx = sorted.findIndex(s => s.id === sessionId)
       setPrevNext({

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -5,7 +5,7 @@ import type { SessionDetail as SessionDetailType, EventRecord, MetricsResponse }
 import { ChevronLeftIcon, ChevronRightIcon } from '../components/icons/ChevronIcons'
 import EventTimeline from '../components/EventTimeline'
 import InfoPopover from '../components/InfoPopover'
-import MetricsChart from '../components/MetricsChart'
+import MetricsChart from '../components/MetricsChartSplit'
 import SessionAICard from '../components/SessionAICard'
 import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -23,6 +23,30 @@ export default function SettingsPage() {
   const [passwordError, setPasswordError] = useState<string | null>(null)
   const [isPasswordSubmitting, setIsPasswordSubmitting] = useState(false)
 
+  // Danger zone
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [deleteConfirm, setDeleteConfirm] = useState(false)
+  const [deleteMessage, setDeleteMessage] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  async function handleDeleteAllSessions() {
+    if (!deleteConfirm) {
+      setDeleteConfirm(true)
+      return
+    }
+    setIsDeleting(true)
+    setDeleteError(null)
+    try {
+      await api.deleteAllSessions()
+      setDeleteMessage('All session data deleted.')
+      setDeleteConfirm(false)
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : 'Could not delete sessions')
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
   // SleepHQ import settings
   const [sleephqClientId, setSleephqClientId] = useState('')
   const [sleephqClientSecret, setSleephqClientSecret] = useState('')
@@ -277,6 +301,31 @@ export default function SettingsPage() {
               {isSleephqSubmitting ? 'Saving...' : 'Save SleepHQ settings'}
             </Button>
           </form>
+        </CardContent>
+      </Card>
+      <Card className="border-[var(--danger-text)] bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.45),_transparent_38%),var(--surface-strong)]">
+        <CardHeader>
+          <CardTitle className="text-2xl text-[var(--danger-text)]">Danger Zone</CardTitle>
+          <CardDescription>Permanently delete all imported session data. Your account will remain intact.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {deleteMessage ? <p className="text-sm font-medium text-[var(--olive-deep)]">{deleteMessage}</p> : null}
+          {deleteError ? <p className="text-sm text-[var(--danger-text)]">{deleteError}</p> : null}
+          {deleteConfirm ? (
+            <div className="space-y-3">
+              <p className="text-sm text-[var(--danger-text)] font-medium">Are you sure? This cannot be undone.</p>
+              <div className="flex gap-3">
+                <Button variant="outline" onClick={() => setDeleteConfirm(false)}>Cancel</Button>
+                <Button onClick={handleDeleteAllSessions} disabled={isDeleting} className="bg-[var(--danger-text)] text-white hover:opacity-90">
+                  {isDeleting ? 'Deleting...' : 'Yes, delete everything'}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <Button onClick={handleDeleteAllSessions} variant="outline" className="border-[var(--danger-text)] text-[var(--danger-text)] hover:bg-[var(--danger-soft)]">
+              Delete all session data
+            </Button>
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
feat: split Night Metrics chart into separate panels per metric
Replaces the single combined chart with four stacked panels (Pressure, Resp Rate, Leak, Flow Limitation), each with its own Y-axis scale. Includes gap breaks at mask-off periods and dynamic pressure axis scaling
Easier to read each metric independently.
New DELETE /sessions/all API endpoint scoped to current user