### PR TITLE
chore(docs): remove personal git config reference from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 ## Git
 - Feature work goes on named branches (`feature/<topic>`) with one PR per feature
-- `git config` identity is set globally (`camden.bock@maine.edu` / Camden Bock) — commits work fine
+- Ensure your `git config user.name` and `git config user.email` are set before committing
 
 ## Private files
 - `.newfeatures` — local implementation notes, never commit or push


### PR DESCRIPTION
## Summary

- Removes the hardcoded `camden.bock@maine.edu` / Camden Bock identity note from the Git section of CLAUDE.md
- Replaces it with a generic reminder that applies to all contributors

The original note was written for a single-developer context and would be confusing or misleading to other contributors.

## Test plan

- [x] CLAUDE.md no longer references a specific developer's email or name in the Git section

🤖 Generated with [Claude Code](https://claude.ai/claude-code)