### PR TITLE
feat(deps): make sleephq-client opt-in via SLEEPHQ_ENABLED

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -7,4 +7,3 @@ passlib==1.7.4
 openai==1.109.1
 python-multipart==0.0.27
 httpx>=0.27.0
-sleephq-client @ git+https://github.com/frohoff/sleephq-client.git

--- a/api/routers/import_settings.py
+++ b/api/routers/import_settings.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Optional
@@ -25,6 +26,7 @@ class ImportSettingsResponse(BaseModel):
     sleephq_machine_id: Optional[int] = None
     auto_import_sleephq: bool = False
     lookback_days: int = 30
+    sleephq_enabled: bool = False
 
 
 class ImportSettingsUpdate(BaseModel):
@@ -46,8 +48,10 @@ def get_import_settings(
         {"uid": current_user["id"]},
     ).mappings().first()
 
+    enabled = os.environ.get("SLEEPHQ_ENABLED", "false").lower() == "true"
+
     if row is None:
-        return ImportSettingsResponse()
+        return ImportSettingsResponse(sleephq_enabled=enabled)
 
     return ImportSettingsResponse(
         sleephq_client_id=row["sleephq_client_id"],
@@ -56,6 +60,7 @@ def get_import_settings(
         sleephq_machine_id=row["sleephq_machine_id"],
         auto_import_sleephq=row["auto_import_sleephq"],
         lookback_days=row["lookback_days"],
+        sleephq_enabled=enabled,
     )
 
 
@@ -165,6 +170,12 @@ def trigger_sleephq_import(
         text("SELECT * FROM user_import_settings WHERE user_id = CAST(:uid AS uuid)"),
         {"uid": current_user["id"]},
     ).mappings().first()
+
+    if os.environ.get("SLEEPHQ_ENABLED", "false").lower() != "true":
+        raise HTTPException(
+            status_code=503,
+            detail="SleepHQ integration is not enabled on this server. Set SLEEPHQ_ENABLED=true to enable it.",
+        )
 
     if row is None or not row["sleephq_client_id"] or not row["sleephq_client_secret"]:
         raise HTTPException(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-*}
       API_URL: ${API_URL:-http://localhost:8000}
+      # Set to "true" to enable SleepHQ cloud import (installs sleephq-client at startup)
+      SLEEPHQ_ENABLED: ${SLEEPHQ_ENABLED:-false}
       API_HOST: 0.0.0.0
       API_PORT: 8000
     ports:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,6 +8,11 @@ export API_HOST="${API_HOST:-0.0.0.0}"
 export API_PORT="${API_PORT:-8000}"
 export API_URL="${API_URL:-http://127.0.0.1:${API_PORT}}"
 
+if [ "${SLEEPHQ_ENABLED:-false}" = "true" ]; then
+  pip install --quiet --no-cache-dir \
+    "sleephq-client @ git+https://github.com/frohoff/sleephq-client.git"
+fi
+
 python /app/docker/wait_for_db.py
 
 python - <<'PY' > /usr/share/nginx/html/config.js

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -148,6 +148,7 @@ export interface ImportSettings {
   sleephq_machine_id: number | null
   auto_import_sleephq: boolean
   lookback_days: number
+  sleephq_enabled: boolean
 }
 
 export interface SummaryStats {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -54,6 +54,7 @@ export default function SettingsPage() {
   const [sleephqMessage, setSleephqMessage] = useState<string | null>(null)
   const [sleephqError, setSleephqError] = useState<string | null>(null)
   const [isSleephqSubmitting, setIsSleephqSubmitting] = useState(false)
+  const [sleephqEnabled, setSleephqEnabled] = useState(false)
 
   useEffect(() => {
     if (!user) {
@@ -66,6 +67,7 @@ export default function SettingsPage() {
 
   useEffect(() => {
     api.getImportSettings().then((settings) => {
+      setSleephqEnabled(settings.sleephq_enabled ?? false)
       setSleephqClientId(settings.sleephq_client_id ?? '')
       setSleephqClientSecret(settings.sleephq_client_secret ?? '')
       setSleephqTeamId(settings.sleephq_team_id != null ? String(settings.sleephq_team_id) : '')
@@ -251,7 +253,7 @@ export default function SettingsPage() {
           </form>
         </CardContent>
       </Card>
-      <Card className="bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.45),_transparent_38%),var(--surface-strong)]">
+      {sleephqEnabled && <Card className="bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.45),_transparent_38%),var(--surface-strong)]">
         <CardHeader>
           <CardTitle className="text-2xl">SleepHQ Integration</CardTitle>
           <CardDescription>
@@ -302,7 +304,7 @@ export default function SettingsPage() {
             </Button>
           </form>
         </CardContent>
-      </Card>
+      </Card>}
       <Card className="border-[var(--danger-text)] bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.45),_transparent_38%),var(--surface-strong)]">
         <CardHeader>
           <CardTitle className="text-2xl text-[var(--danger-text)]">Danger Zone</CardTitle>

--- a/importer/sleephq_import.py
+++ b/importer/sleephq_import.py
@@ -43,11 +43,15 @@ from typing import Optional
 
 import httpx
 
-from sleephq import AuthenticatedClient
-from sleephq.auth import create_client as _sleephq_create_client
-from sleephq.api.machine_dates import get_v1_machines_machine_id_machine_dates
-from sleephq.api.teams import get_v1_teams
-from sleephq.api.machines import get_v1_teams_team_id_machines
+try:
+    from sleephq import AuthenticatedClient
+    from sleephq.auth import create_client as _sleephq_create_client
+    from sleephq.api.machine_dates import get_v1_machines_machine_id_machine_dates
+    from sleephq.api.teams import get_v1_teams
+    from sleephq.api.machines import get_v1_teams_team_id_machines
+    _SLEEPHQ_AVAILABLE = True
+except ImportError:
+    _SLEEPHQ_AVAILABLE = False
 
 from db import get_conn, session_exists, upsert_session
 
@@ -124,6 +128,14 @@ def _api_call_with_retry(fn, *args, label: str = "API call", **kwargs):
 # Client / authentication
 # ---------------------------------------------------------------------------
 
+def _require_sleephq():
+    if not _SLEEPHQ_AVAILABLE:
+        raise RuntimeError(
+            "sleephq-client is not installed. "
+            "Set SLEEPHQ_ENABLED=true in your environment to enable SleepHQ support."
+        )
+
+
 def create_sleephq_client(
     client_id: Optional[str] = None,
     client_secret: Optional[str] = None,
@@ -134,6 +146,7 @@ def create_sleephq_client(
     Retries up to ``_MAX_ATTEMPTS`` times on HTTP 429 (rate limit) with
     exponential back-off, honouring the ``Retry-After`` header when present.
     """
+    _require_sleephq()
     cid = client_id or os.environ["SLEEPHQ_CLIENT_ID"]
     csecret = client_secret or os.environ["SLEEPHQ_CLIENT_SECRET"]
 
@@ -601,6 +614,7 @@ def run_sleephq_import(
     should inject them via client_id / client_secret rather than
     mutating os.environ directly.
     """
+    _require_sleephq()
     # Temporarily override env vars if explicit creds provided
     _orig = {}
     if client_id:

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 
@@ -11,6 +12,7 @@ class TestGetSettings:
         assert data["sleephq_client_secret"] is None
         assert data["auto_import_sleephq"] is False
         assert data["lookback_days"] == 30
+        assert data["sleephq_enabled"] is False
 
     def test_after_save(self, client: TestClient, auth_headers):
         client.put("/import/settings", headers=auth_headers, json={
@@ -61,8 +63,15 @@ class TestPutSettings:
 
 
 class TestTrigger:
-    def test_without_credentials(self, client: TestClient, auth_headers):
+    def test_disabled(self, client: TestClient, auth_headers):
+        # SLEEPHQ_ENABLED unset (default) → 503 before credential check
         resp = client.post("/import/trigger", headers=auth_headers)
+        assert resp.status_code == 503
+        assert "SLEEPHQ_ENABLED" in resp.json()["detail"]
+
+    def test_without_credentials(self, client: TestClient, auth_headers):
+        with patch.dict("os.environ", {"SLEEPHQ_ENABLED": "true"}):
+            resp = client.post("/import/trigger", headers=auth_headers)
         assert resp.status_code == 400
         assert "credentials" in resp.json()["detail"].lower()
 
@@ -72,7 +81,8 @@ class TestTrigger:
             "sleephq_client_id": "test-id",
             "sleephq_client_secret": "test-secret",
         })
-        resp = client.post("/import/trigger", headers=auth_headers)
+        with patch.dict("os.environ", {"SLEEPHQ_ENABLED": "true"}):
+            resp = client.post("/import/trigger", headers=auth_headers)
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "started"

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
 from fastapi.testclient import TestClient
 
 


### PR DESCRIPTION
## Summary

The vast majority of users running this stack will never use the SleepHQ cloud import. Despite that, `sleephq-client` (a git-sourced dependency with no declared license) was previously baked into the Docker image for everyone, adding build time, image size, and a transient dependency on an external git repo on every pull.

This PR removes `sleephq-client` from the default dependency set entirely. Users who need SleepHQ import opt in by setting `SLEEPHQ_ENABLED=true` in their environment; the package is installed at container startup only when that flag is present.

## Licensing note

Moving `sleephq-client` out of the default dependency stack also keeps the project's own licensing question open. As a runtime opt-in rather than a required dependency, it no longer influences the license this repo can adopt — that decision can be driven by other dependencies (e.g. any OSCAR-derived code) or by the project's own preferences, without `sleephq-client`'s unlicensed status being a blocker for the majority of users.

## Changes

**Dependency removal**
- `sleephq-client` removed from `api/requirements.txt` — no longer installed in the base image

**Runtime opt-in (`docker/entrypoint.sh`)**
- If `SLEEPHQ_ENABLED=true`, the entrypoint installs `sleephq-client` via pip before starting the server (`git` is already present in the image)
- Default (`SLEEPHQ_ENABLED=false` or unset): package is never fetched or installed

**Graceful degradation (`importer/sleephq_import.py`)**
- Top-level `sleephq` imports wrapped in `try/except ImportError`; `_SLEEPHQ_AVAILABLE` flag set accordingly
- `create_sleephq_client` and `run_sleephq_import` call `_require_sleephq()` at entry, raising a clear `RuntimeError` if the package is absent rather than crashing with a raw `ImportError`

**API (`api/routers/import_settings.py`)**
- `GET /import/settings` returns `sleephq_enabled: bool` derived from the env var
- `POST /import/trigger` returns 503 with a clear message before dispatching to the background task if `SLEEPHQ_ENABLED` is not set — prevents the previous silent failure path where the background task would crash and the frontend would show "started" with nothing happening

**Frontend (`frontend/src/pages/Settings.tsx`, `frontend/src/api/client.ts`)**
- `sleephq_enabled` added to `ImportSettings` type
- The entire SleepHQ Integration card is hidden when `sleephq_enabled` is false — users without the feature enabled see no SleepHQ UI at all

**docker-compose.yml**
- `SLEEPHQ_ENABLED: ${SLEEPHQ_ENABLED:-false}` added with a comment explaining the flag

## Test plan

- [x] Default (no `SLEEPHQ_ENABLED`): Settings page shows no SleepHQ Integration card; `POST /import/trigger` returns 503
- [x] `SLEEPHQ_ENABLED=true`: SleepHQ Integration card visible; trigger endpoint works normally
- [x] `npm run build` passes
- [x] `uv run pytest -v --tb=short` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)