### PR TITLE
feat(timezone): MACHINE_TZ and DISPLAY_TZ — correct EDF timestamp storage and plot labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,28 @@ Default local URLs:
 - Frontend: `http://127.0.0.1:5173`
 - API: `http://127.0.0.1:8000`
 
+## Timezones
+
+Two IANA timezone settings control how session data is interpreted and displayed.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `MACHINE_TZ` | `UTC` | The timezone your CPAP machine is set to. The importer uses this to correctly interpret the naive local timestamps embedded in EDF files before storing them as UTC in the database. |
+| `DISPLAY_TZ` | `UTC` | The timezone used to format all time labels in the UI — plot axes, event timeline, session start time. Set this to your local timezone for accurate display. |
+
+Both values must be valid [IANA timezone names](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (e.g. `America/New_York`, `Europe/London`, `Australia/Sydney`).
+
+Set them in your `.env` file or `docker-compose.yml`:
+
+```env
+MACHINE_TZ=America/New_York
+DISPLAY_TZ=America/New_York
+```
+
+If your machine is set to the same timezone as your display, both values will be identical. If you travel with your CPAP and don't update the machine clock, set `MACHINE_TZ` to the machine's home timezone and `DISPLAY_TZ` to wherever you want times displayed.
+
+> **Re-importing after changing `MACHINE_TZ`:** The importer attaches the timezone at import time. If you change `MACHINE_TZ` after sessions are already in the database, re-run the importer with `--from` to update affected sessions.
+
 ## Auth
 
 SleepLab uses bearer-token auth.

--- a/api/main.py
+++ b/api/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .routers import auth as auth_router
-from .routers import sessions, stats, upload, ai_summary, llm, import_settings as import_settings_router
+from .routers import sessions, stats, upload, ai_summary, llm, import_settings as import_settings_router, config
 from .env import load_env
 
 load_env()
@@ -43,6 +43,7 @@ app.include_router(upload.router, prefix="/upload", tags=["upload"])
 app.include_router(ai_summary.router, prefix="/stats", tags=["stats"])
 app.include_router(llm.router, prefix="/llm", tags=["llm"])
 app.include_router(import_settings_router.router, prefix="/import", tags=["import"])
+app.include_router(config.router, prefix="/config", tags=["config"])
 
 
 @app.get("/health")

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -1,0 +1,30 @@
+"""
+App configuration endpoint.
+
+GET /config  — returns server-side settings the frontend needs at runtime,
+               including the display timezone for plot labels.
+"""
+
+import os
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("")
+def get_config():
+    """
+    Return runtime configuration for the frontend.
+
+    display_tz  IANA timezone name used to format all time labels in the UI
+                (plot axes, event timeline, session start time).  Defaults to UTC.
+
+    machine_tz  IANA timezone name the CPAP machine was set to when sessions
+                were recorded.  The importer uses this to correctly interpret
+                the naive local timestamps embedded in EDF files.  Defaults to UTC.
+    """
+    return {
+        "display_tz": os.environ.get("DISPLAY_TZ", "UTC"),
+        "machine_tz": os.environ.get("MACHINE_TZ", "UTC"),
+    }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,13 @@ services:
       API_URL: ${API_URL:-http://localhost:8000}
       API_HOST: 0.0.0.0
       API_PORT: 8000
+      # Timezone the CPAP machine is set to.  Used by the importer to correctly
+      # interpret naive local timestamps in EDF files before storing as UTC.
+      # Must be a valid IANA timezone name, e.g. America/New_York, Europe/London.
+      MACHINE_TZ: ${MACHINE_TZ:-UTC}
+      # Timezone used to format time labels on plots and session cards in the UI.
+      # Defaults to UTC; set to your local timezone for accurate display.
+      DISPLAY_TZ: ${DISPLAY_TZ:-UTC}
     ports:
       - "8080:8080"
       - "8000:8000"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { Link, Navigate, Route, Routes, useLocation, useNavigate } from 'react-r
 import { BrowserRouter } from 'react-router-dom'
 
 import { api } from './api/client'
+import { setDisplayTz } from './lib/displayTz'
 import {
   ActivityIcon,
   CalendarIcon,
@@ -79,6 +80,11 @@ function AppLayout() {
   const [isSyncing, setIsSyncing] = useState(false)
   const userMenuRef = useRef<HTMLDivElement | null>(null)
   const wasSyncingRef = useRef(false)
+
+  // Fetch display timezone from server config once on mount.
+  useEffect(() => {
+    api.getAppConfig().then((cfg) => setDisplayTz(cfg.display_tz)).catch(() => {})
+  }, [])
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -141,6 +141,11 @@ export interface DailyStat {
   session_id: string
 }
 
+export interface AppConfig {
+  display_tz: string
+  machine_tz: string
+}
+
 export interface ImportSettings {
   sleephq_client_id: string | null
   sleephq_client_secret: string | null
@@ -279,6 +284,7 @@ export const api = {
   getImportSettings: () => get<ImportSettings>('/import/settings'),
   saveImportSettings: (payload: Partial<ImportSettings>) => put<ImportSettings>('/import/settings', payload),
   triggerSleepHQImport: () => post<{ status: string; message: string }>('/import/trigger'),
+  getAppConfig: () => get<AppConfig>('/config'),
 }
 
 export const authTokenStore = {

--- a/frontend/src/components/EventTimeline.tsx
+++ b/frontend/src/components/EventTimeline.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
 import type { EventRecord } from '../api/client'
+import { getDisplayTz } from '../lib/displayTz'
 
 interface Props {
   events: EventRecord[]
@@ -18,7 +19,7 @@ const EVENT_COLORS: Record<string, string> = {
 
 function fmtTime(startIso: string, offsetSeconds: number): string {
   const d = new Date(new Date(startIso).getTime() + offsetSeconds * 1000)
-  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: getDisplayTz() })
 }
 
 export default function EventTimeline({ events, durationSeconds, startDatetime }: Props) {

--- a/frontend/src/components/MetricsChart.tsx
+++ b/frontend/src/components/MetricsChart.tsx
@@ -3,6 +3,7 @@ import {
   Legend, ResponsiveContainer
 } from 'recharts'
 import type { MetricsResponse } from '../api/client'
+import { getDisplayTz } from '../lib/displayTz'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
 
 interface Props {
@@ -40,7 +41,7 @@ export default function MetricsChart({ metrics }: Props) {
   }
 
   function fmtTs(ts: number) {
-    return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: getDisplayTz() })
   }
 
   return (

--- a/frontend/src/lib/displayTz.ts
+++ b/frontend/src/lib/displayTz.ts
@@ -1,0 +1,21 @@
+/**
+ * Module-level display timezone singleton.
+ *
+ * Initialised to the browser's local timezone so the app works correctly
+ * before the server config is fetched.  App.tsx overwrites it with the
+ * DISPLAY_TZ value from GET /config on startup.
+ *
+ * Usage:
+ *   import { getDisplayTz } from '../lib/displayTz'
+ *   new Date(ts).toLocaleTimeString([], { timeZone: getDisplayTz(), ... })
+ */
+
+let _tz: string = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+export function getDisplayTz(): string {
+  return _tz
+}
+
+export function setDisplayTz(tz: string): void {
+  _tz = tz
+}

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { api } from '../api/client'
+import { getDisplayTz } from '../lib/displayTz'
 import type { SessionDetail as SessionDetailType, EventRecord, MetricsResponse } from '../api/client'
 import { ChevronLeftIcon, ChevronRightIcon } from '../components/icons/ChevronIcons'
 import EventTimeline from '../components/EventTimeline'
@@ -11,11 +12,11 @@ import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
 
 function fmtDate(iso: string) {
-  return new Date(iso).toLocaleDateString([], { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })
+  return new Date(iso).toLocaleDateString([], { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', timeZone: getDisplayTz() })
 }
 
 function fmtTime(iso: string) {
-  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: getDisplayTz() })
 }
 
 

--- a/importer/import_sessions.py
+++ b/importer/import_sessions.py
@@ -8,11 +8,13 @@ Run:
     python import_sessions.py --from 20250101     # from date onward
 """
 
+import os
 import sys
 import argparse
 import statistics
 from pathlib import Path
 from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from edf_parser import parse_pld, parse_eve, parse_sa2, read_header
 from db import (
@@ -26,6 +28,21 @@ from db import (
 
 
 AHI_EVENT_TYPES = {'Central Apnea', 'Obstructive Apnea', 'Hypopnea', 'Apnea'}
+
+
+def _machine_tz() -> ZoneInfo:
+    """Return the ZoneInfo for MACHINE_TZ, falling back to UTC on invalid input."""
+    name = os.environ.get("MACHINE_TZ", "UTC")
+    try:
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, KeyError):
+        print(f"  WARNING: unknown MACHINE_TZ={name!r}, falling back to UTC", flush=True)
+        return ZoneInfo("UTC")
+
+
+def _localize(naive_dt: datetime) -> datetime:
+    """Attach MACHINE_TZ to a naive datetime from an EDF header."""
+    return naive_dt.replace(tzinfo=_machine_tz())
 
 
 def discover_session_blocks(folder: Path) -> list:
@@ -151,13 +168,15 @@ def import_folder(folder: Path, folder_date: date, conn, user_id: str):
             if block['eve_path'] and block['eve_path'].exists():
                 _, events = parse_eve(block['eve_path'])
 
-            # Get CSL start datetime for event absolute timestamps
-            csl_start = pld_header.start_datetime  # fallback
+            # Get CSL start datetime for event absolute timestamps.
+            # EDF timestamps are naive local machine time; attach MACHINE_TZ so
+            # psycopg2 stores the correct UTC equivalent in TIMESTAMPTZ columns.
+            csl_start = _localize(pld_header.start_datetime)  # fallback
             if block['csl_path'] and block['csl_path'].exists():
                 csl_hdr = read_header(str(block['csl_path']))
-                csl_start = csl_hdr.start_datetime
+                csl_start = _localize(csl_hdr.start_datetime)
 
-            pld_start = pld_header.start_datetime
+            pld_start = _localize(pld_header.start_datetime)
             duration_s = int(pld_header.num_records * pld_header.duration_per_record)
 
             # Parse SA2 (optional)

--- a/importer/import_sessions.py
+++ b/importer/import_sessions.py
@@ -35,7 +35,7 @@ def _machine_tz() -> ZoneInfo:
     name = os.environ.get("MACHINE_TZ", "UTC")
     try:
         return ZoneInfo(name)
-    except (ZoneInfoNotFoundError, KeyError):
+    except (ZoneInfoNotFoundError, KeyError, ValueError):
         print(f"  WARNING: unknown MACHINE_TZ={name!r}, falling back to UTC", flush=True)
         return ZoneInfo("UTC")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 markers = [
     "db: tests that require a Postgres database",
 ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,3 @@
-import pytest
 from fastapi.testclient import TestClient
 
 from api.main import app

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,37 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+client = TestClient(app)
+
+
+class TestGetConfig:
+    def test_defaults_to_utc(self, monkeypatch):
+        monkeypatch.delenv("DISPLAY_TZ", raising=False)
+        monkeypatch.delenv("MACHINE_TZ", raising=False)
+        resp = client.get("/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["display_tz"] == "UTC"
+        assert data["machine_tz"] == "UTC"
+
+    def test_reflects_env_vars(self, monkeypatch):
+        monkeypatch.setenv("DISPLAY_TZ", "America/New_York")
+        monkeypatch.setenv("MACHINE_TZ", "America/Chicago")
+        resp = client.get("/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["display_tz"] == "America/New_York"
+        assert data["machine_tz"] == "America/Chicago"
+
+    def test_no_auth_required(self):
+        resp = client.get("/config")
+        assert resp.status_code == 200
+
+    def test_response_shape(self):
+        resp = client.get("/config")
+        data = resp.json()
+        assert set(data.keys()) == {"display_tz", "machine_tz"}
+        assert isinstance(data["display_tz"], str)
+        assert isinstance(data["machine_tz"], str)

--- a/tests/test_importer_timezone.py
+++ b/tests/test_importer_timezone.py
@@ -1,0 +1,92 @@
+"""
+Unit tests for _machine_tz() and _localize() in the importer.
+
+These are pure-Python helpers with no DB or file I/O, so no fixtures needed.
+"""
+
+import sys
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+# importer/ is not a package — add it to sys.path so we can import directly
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "importer"))
+
+from import_sessions import _localize, _machine_tz
+
+
+class TestMachineTz:
+    def test_defaults_to_utc(self, monkeypatch):
+        monkeypatch.delenv("MACHINE_TZ", raising=False)
+        assert _machine_tz() == ZoneInfo("UTC")
+
+    def test_valid_iana_name(self, monkeypatch):
+        monkeypatch.setenv("MACHINE_TZ", "America/New_York")
+        assert _machine_tz() == ZoneInfo("America/New_York")
+
+    def test_invalid_name_falls_back_to_utc(self, monkeypatch, capsys):
+        monkeypatch.setenv("MACHINE_TZ", "Not/A/Real/Zone")
+        result = _machine_tz()
+        assert result == ZoneInfo("UTC")
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out
+        assert "Not/A/Real/Zone" in captured.out
+
+    def test_empty_string_falls_back_to_utc(self, monkeypatch, capsys):
+        monkeypatch.setenv("MACHINE_TZ", "")
+        result = _machine_tz()
+        assert result == ZoneInfo("UTC")
+
+    def test_various_valid_zones(self, monkeypatch):
+        for tz_name in ("Europe/London", "Asia/Tokyo", "US/Pacific", "UTC"):
+            monkeypatch.setenv("MACHINE_TZ", tz_name)
+            assert _machine_tz() == ZoneInfo(tz_name)
+
+
+class TestLocalize:
+    def test_attaches_timezone_to_naive(self, monkeypatch):
+        monkeypatch.setenv("MACHINE_TZ", "America/New_York")
+        naive = datetime(2025, 1, 15, 23, 0, 0)
+        result = _localize(naive)
+        assert result.tzinfo == ZoneInfo("America/New_York")
+        assert result.year == 2025
+        assert result.hour == 23
+
+    def test_utc_offset_correct_for_eastern(self, monkeypatch):
+        monkeypatch.setenv("MACHINE_TZ", "America/New_York")
+        # Jan 15 23:00 Eastern Standard Time = Jan 16 04:00 UTC
+        naive = datetime(2025, 1, 15, 23, 0, 0)
+        result = _localize(naive)
+        utc = result.astimezone(timezone.utc)
+        assert utc.day == 16
+        assert utc.hour == 4
+
+    def test_utc_offset_correct_for_tokyo(self, monkeypatch):
+        monkeypatch.setenv("MACHINE_TZ", "Asia/Tokyo")
+        # Jan 15 08:00 JST (UTC+9) = Jan 14 23:00 UTC
+        naive = datetime(2025, 1, 15, 8, 0, 0)
+        result = _localize(naive)
+        utc = result.astimezone(timezone.utc)
+        assert utc.day == 14
+        assert utc.hour == 23
+
+    def test_dst_aware_summer_eastern(self, monkeypatch):
+        monkeypatch.setenv("MACHINE_TZ", "America/New_York")
+        # Jul 15 22:00 EDT (UTC-4) = Jul 16 02:00 UTC
+        naive = datetime(2025, 7, 15, 22, 0, 0)
+        result = _localize(naive)
+        utc = result.astimezone(timezone.utc)
+        assert utc.day == 16
+        assert utc.hour == 2
+
+    def test_invalid_tz_falls_back_to_utc(self, monkeypatch):
+        monkeypatch.setenv("MACHINE_TZ", "Fake/Zone")
+        naive = datetime(2025, 1, 15, 22, 0, 0)
+        result = _localize(naive)
+        assert result.tzinfo == ZoneInfo("UTC")
+        # UTC offset is 0 so UTC equivalent equals the naive time
+        utc = result.astimezone(timezone.utc)
+        assert utc.hour == 22

--- a/tests/test_importer_timezone.py
+++ b/tests/test_importer_timezone.py
@@ -5,12 +5,9 @@ These are pure-Python helpers with no DB or file I/O, so no fixtures needed.
 """
 
 import sys
-import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo
-
-import pytest
 
 # importer/ is not a package — add it to sys.path so we can import directly
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "importer"))
@@ -60,7 +57,7 @@ class TestLocalize:
         # Jan 15 23:00 Eastern Standard Time = Jan 16 04:00 UTC
         naive = datetime(2025, 1, 15, 23, 0, 0)
         result = _localize(naive)
-        utc = result.astimezone(timezone.utc)
+        utc = result.astimezone(UTC)
         assert utc.day == 16
         assert utc.hour == 4
 
@@ -69,7 +66,7 @@ class TestLocalize:
         # Jan 15 08:00 JST (UTC+9) = Jan 14 23:00 UTC
         naive = datetime(2025, 1, 15, 8, 0, 0)
         result = _localize(naive)
-        utc = result.astimezone(timezone.utc)
+        utc = result.astimezone(UTC)
         assert utc.day == 14
         assert utc.hour == 23
 
@@ -78,7 +75,7 @@ class TestLocalize:
         # Jul 15 22:00 EDT (UTC-4) = Jul 16 02:00 UTC
         naive = datetime(2025, 7, 15, 22, 0, 0)
         result = _localize(naive)
-        utc = result.astimezone(timezone.utc)
+        utc = result.astimezone(UTC)
         assert utc.day == 16
         assert utc.hour == 2
 
@@ -88,5 +85,5 @@ class TestLocalize:
         result = _localize(naive)
         assert result.tzinfo == ZoneInfo("UTC")
         # UTC offset is 0 so UTC equivalent equals the naive time
-        utc = result.astimezone(timezone.utc)
+        utc = result.astimezone(UTC)
         assert utc.hour == 22


### PR DESCRIPTION
## Summary

- Introduces \`MACHINE_TZ\` and \`DISPLAY_TZ\` env vars (IANA timezone names, both default to UTC)
- **Importer**: \`_machine_tz()\` / \`_localize()\` attach \`MACHINE_TZ\` to naive EDF datetimes before writing to \`TIMESTAMPTZ\` columns — prevents the UTC-shift bug where Eastern users' sessions land on the wrong date
- **API**: new \`GET /config\` endpoint (no auth) returns \`{display_tz, machine_tz}\` for the frontend
- **Frontend**: \`App.tsx\` fetches \`/config\` on mount; \`displayTz.ts\` singleton propagates \`DISPLAY_TZ\` to all \`toLocaleTimeString\` / \`toLocaleDateString\` calls in \`MetricsChart\`, \`EventTimeline\`, and \`SessionDetail\`
- **README**: new Timezones section with IANA examples, travel note, re-import guidance

## Bug fix

\`_machine_tz()\` now catches \`ValueError\` in addition to \`ZoneInfoNotFoundError\` / \`KeyError\` — an empty \`MACHINE_TZ=""\` would previously crash the importer rather than falling back to UTC.

## Tests (14 passing)

- \`tests/test_config.py\` — \`GET /config\` defaults, env var passthrough, no-auth access, response shape
- \`tests/test_importer_timezone.py\` — \`_machine_tz()\` valid IANA names, invalid/empty fallback with warning, \`_localize()\` UTC offset correctness (Eastern/Tokyo), DST awareness

Adds \`pythonpath = ["."]\` to \`pyproject.toml\` so \`importer/\` is importable in the test suite.

## Test plan
- [x] Set \`MACHINE_TZ=America/New_York\`, import a session at 21:02 EDT — stored UTC is next-day 01:02Z ✓
- [x] Set \`DISPLAY_TZ=America/New_York\` — \`GET /config\` returns \`"display_tz": "America/New_York"\` ✓
- [x] Leave both unset — \`GET /config\` returns \`"display_tz": "UTC", "machine_tz": "UTC"\`, no crash ✓
- [x] Set \`MACHINE_TZ=garbage\` — importer logs WARNING and continues with UTC (unit test) ✓
- [x] \`uv run pytest tests/test_config.py tests/test_importer_timezone.py -v\` — 14 pass ✓

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)