### PR TITLE
feat(ui): date-based session URLs (/sessions/YYYY-MM-DD)

### DIFF
--- a/api/routers/sessions.py
+++ b/api/routers/sessions.py
@@ -319,3 +319,59 @@ def delete_all_sessions(
         {"uid": current_user["id"]},
     )
     db.commit()
+
+
+@router.get("/by-date/{folder_date}", response_model=SessionDetail)
+def get_session_by_date(
+    folder_date: str,
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get session detail by date (YYYY-MM-DD)."""
+    row = db.execute(
+        text("""
+            WITH night AS (
+                SELECT folder_date, user_id
+                FROM sessions
+                WHERE folder_date = CAST(:date AS date) AND user_id = CAST(:uid AS uuid)
+                LIMIT 1
+            )
+            SELECT
+                (array_agg(s.id::text ORDER BY s.duration_seconds DESC))[1] AS id,
+                (array_agg(s.session_id ORDER BY s.duration_seconds DESC))[1] AS session_id,
+                s.folder_date,
+                0 AS block_index,
+                MIN(s.start_datetime) AS start_datetime,
+                MIN(s.start_datetime) AS pld_start_datetime,
+                SUM(s.duration_seconds) AS duration_seconds,
+                SUM(s.total_ahi_events) AS total_ahi_events,
+                SUM(s.central_apnea_count) AS central_apnea_count,
+                SUM(s.obstructive_apnea_count) AS obstructive_apnea_count,
+                SUM(s.hypopnea_count) AS hypopnea_count,
+                SUM(s.apnea_count) AS apnea_count,
+                SUM(s.arousal_count) AS arousal_count,
+                AVG(s.avg_pressure) AS avg_pressure,
+                MAX(s.p95_pressure) AS p95_pressure,
+                AVG(s.avg_leak) AS avg_leak,
+                BOOL_OR(s.has_spo2) AS has_spo2,
+                CASE WHEN SUM(s.duration_seconds) > 0
+                     THEN ROUND((SUM(s.total_ahi_events) / (SUM(s.duration_seconds) / 3600.0))::numeric, 2)
+                     ELSE 0 END AS ahi,
+                AVG(s.avg_resp_rate) AS avg_resp_rate,
+                AVG(s.avg_tidal_vol) AS avg_tidal_vol,
+                AVG(s.avg_min_vent) AS avg_min_vent,
+                AVG(s.avg_snore) AS avg_snore,
+                AVG(s.avg_flow_lim) AS avg_flow_lim,
+                AVG(s.avg_spo2) AS avg_spo2,
+                MIN(s.min_spo2) AS min_spo2,
+                (array_agg(s.device_serial ORDER BY s.duration_seconds DESC))[1] AS device_serial
+            FROM sessions s
+            JOIN night n ON s.folder_date = n.folder_date AND s.user_id = n.user_id
+            WHERE s.duration_seconds >= 600
+            GROUP BY s.folder_date
+        """),
+        {"date": folder_date, "uid": current_user["id"]},
+    ).mappings().first()
+    if not row:
+        raise HTTPException(status_code=404, detail="No session found for this date")
+    return SessionDetail.model_validate(dict(row))

--- a/api/routers/sessions.py
+++ b/api/routers/sessions.py
@@ -364,7 +364,11 @@ def get_session_by_date(
                 AVG(s.avg_flow_lim) AS avg_flow_lim,
                 AVG(s.avg_spo2) AS avg_spo2,
                 MIN(s.min_spo2) AS min_spo2,
-                (array_agg(s.device_serial ORDER BY s.duration_seconds DESC))[1] AS device_serial
+                (array_agg(s.device_serial   ORDER BY s.duration_seconds DESC))[1] AS device_serial,
+                (array_agg(s.therapy_mode    ORDER BY s.duration_seconds DESC))[1] AS therapy_mode,
+                (array_agg(s.mask_type       ORDER BY s.duration_seconds DESC))[1] AS mask_type,
+                (array_agg(s.humidity_level  ORDER BY s.duration_seconds DESC))[1] AS humidity_level,
+                (array_agg(s.temperature_c   ORDER BY s.duration_seconds DESC))[1] AS temperature_c
             FROM sessions s
             JOIN night n ON s.folder_date = n.folder_date AND s.user_id = n.user_id
             WHERE s.duration_seconds >= 600

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -183,7 +183,7 @@ function AppLayout() {
       <Route path="/calendar" element={<ProtectedRoute><CalendarPage /></ProtectedRoute>} />
       <Route path="/trends" element={<ProtectedRoute><TrendsPage /></ProtectedRoute>} />
       <Route path="/insights" element={<ProtectedRoute><InsightsPage /></ProtectedRoute>} />
-      <Route path="/sessions/:id" element={<ProtectedRoute><SessionDetail /></ProtectedRoute>} />
+      <Route path="/sessions/:date" element={<ProtectedRoute><SessionDetail /></ProtectedRoute>} />
       <Route path="/import" element={<ProtectedRoute><ImportPage /></ProtectedRoute>} />
       <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
     </Routes>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -332,6 +332,7 @@ export const api = {
   getSessions: (params?: { per_page?: number; date_from?: string; date_to?: string }) =>
     get<SessionSummary[]>('/sessions/', params as Record<string, string | number> | undefined),
   getSession: (id: string) => get<SessionDetail>(`/sessions/${id}`),
+  getSessionByDate: (date: string) => get<SessionDetail>(`/sessions/by-date/${date}`),
   getEvents: (id: string) => get<EventRecord[]>(`/sessions/${id}/events`),
   getMetrics: (id: string, downsample = 15) =>
     get<MetricsResponse>(`/sessions/${id}/metrics`, { downsample }),

--- a/frontend/src/components/AHITrendChart.tsx
+++ b/frontend/src/components/AHITrendChart.tsx
@@ -28,7 +28,7 @@ export default function AHITrendChart({ trend }: Props) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const payload = e as any
             if (payload?.activePayload?.[0]?.payload?.sessionId) {
-              navigate(`/sessions/${payload.activePayload[0].payload.sessionId}`)
+              navigate(`/sessions/${payload.activePayload[0].payload.date}`)
             }
           }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#d8dcdd" />

--- a/frontend/src/components/CalendarHeatmap.tsx
+++ b/frontend/src/components/CalendarHeatmap.tsx
@@ -99,7 +99,7 @@ export default function CalendarHeatmap({ sessions }: Props) {
                     className="h-4 w-4 rounded-sm transition hover:scale-110"
                     style={{ background: color, cursor: entry ? 'pointer' : 'default' }}
                     title={label}
-                    onClick={() => entry && navigate(`/sessions/${entry.sessionId}`)}
+                    onClick={() => entry && navigate(`/sessions/${iso}`)}
                   />
                 )
               })}

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -31,9 +31,9 @@ function ahiBadge(ahi: number | null): { label: string; className: string } {
 }
 
 export default function SessionDetail() {
-  const { id } = useParams<{ id: string }>()
+  const { date } = useParams<{ date: string }>()
   const navigate = useNavigate()
-  const sessionId = id ?? ''
+  const sessionDate = date ?? ''
 
   const [session, setSession] = useState<SessionDetailType | null>(null)
   const [events, setEvents] = useState<EventRecord[]>([])
@@ -50,27 +50,30 @@ export default function SessionDetail() {
     setEquipment(null)
     setWearableData(null)
     Promise.all([
-      api.getSession(sessionId),
-      api.getEvents(sessionId),
-      api.getMetrics(sessionId, 15),
-    ]).then(([s, e, m]) => {
+      api.getSessionByDate(sessionDate),
+    ]).then(([s]) => {
       setSession(s)
-      setEvents(e)
-      setMetrics(m)
-      setLoading(false)
-      if (s.has_spo2) {
-        api.getSessionSpo2(sessionId).then(setSpo2).catch(() => setSpo2(null))
-      }
-      api.getInferredEquipment(s.folder_date.toString()).then(setEquipment).catch(() => setEquipment(null))
-      api.getWearableData(s.folder_date).then((data) => {
-        if (!data.hr.length && !data.spo2.length && !data.stages.length) {
-          setWearableData(null)
-          return
+      return Promise.all([
+        api.getEvents(s.id),
+        api.getMetrics(s.id, 15),
+      ]).then(([e, m]) => {
+        setEvents(e)
+        setMetrics(m)
+        setLoading(false)
+        if (s.has_spo2) {
+          api.getSessionSpo2(s.id).then(setSpo2).catch(() => setSpo2(null))
         }
-        setWearableData(data)
-      }).catch(() => setWearableData(null))
+        api.getInferredEquipment(s.folder_date.toString()).then(setEquipment).catch(() => setEquipment(null))
+        api.getWearableData(s.folder_date).then((data) => {
+          if (!data.hr.length && !data.spo2.length && !data.stages.length) {
+            setWearableData(null)
+            return
+          }
+          setWearableData(data)
+        }).catch(() => setWearableData(null))
+      })
     }).catch(() => navigate('/dashboard'))
-  }, [navigate, sessionId])
+  }, [navigate, sessionDate])
 
   useEffect(() => {
     if (!session) return
@@ -78,13 +81,13 @@ export default function SessionDetail() {
       const sorted = all
         
         .sort((a, b) => a.folder_date.localeCompare(b.folder_date))
-      const idx = sorted.findIndex(s => s.id === sessionId)
+      const idx = sorted.findIndex(s => s.folder_date === sessionDate)
       setPrevNext({
-        prev: idx > 0 ? sorted[idx - 1].id : null,
-        next: idx < sorted.length - 1 ? sorted[idx + 1].id : null,
+        prev: idx > 0 ? sorted[idx - 1].folder_date : null,
+        next: idx < sorted.length - 1 ? sorted[idx + 1].folder_date : null,
       })
     })
-  }, [session, sessionId])
+  }, [session, sessionDate])
 
   if (loading) return <div className="rounded-[28px] border border-[var(--border)] bg-[var(--surface-strong)] p-10 text-center text-[var(--muted-foreground)]">Loading session...</div>
   if (!session || !metrics) return null
@@ -288,7 +291,7 @@ export default function SessionDetail() {
         </Card>
       )}
 
-      <SessionAICard sessionId={sessionId} />
+      <SessionAICard sessionId={session.id} />
 
       <Card>
         <CardHeader>


### PR DESCRIPTION
**feat: date-based session URLs**

Replaces UUID-based session URLs with human-readable dates.

**Before:** `/sessions/3afd555e-25e9-428e-be8c-a36dee3f27c2`
**After:** `/sessions/2026-05-14`

**Changes:**
- New `GET /sessions/by-date/{YYYY-MM-DD}` API endpoint that aggregates all blocks for a night and returns full session detail
- Frontend route changed from `/sessions/:id` to `/sessions/:date`
- Calendar heatmap and AHI trend chart navigate to date-based URLs
- Previous/next night navigation uses dates
- Session detail loads by date then fetches events and metrics using the resolved session UUID

Dates are more meaningful to users than UUIDs — you can read the URL and immediately know which night you're looking at, and URLs are now bookmarkable and shareable in a human-readable way.