### PR TITLE
fix(deps): replace python-jose with PyJWT to restore CI

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from jose import JWTError, jwt
+import jwt
 from passlib.context import CryptContext
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -60,7 +60,7 @@ def get_current_user(
         user_id_str: Optional[str] = payload.get("sub")
         if user_id_str is None:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
-    except JWTError:
+    except jwt.InvalidTokenError:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired token")
 
     row = db.execute(

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.124.4
 uvicorn==0.33.0
 sqlalchemy==2.0.46
 psycopg2-binary==2.9.10
-python-jose==3.5.0
+PyJWT==2.10.1
 passlib==1.7.4
 openai==1.109.1
 python-multipart==0.0.27

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,11 @@ dependencies = [
     "uvicorn==0.33.0",
     "sqlalchemy==2.0.46",
     "psycopg2-binary==2.9.10",
-    "python-jose==3.5.0",
+    "PyJWT==2.10.1",
     "passlib==1.7.4",
     "openai==1.109.1",
     "python-multipart==0.0.27",
     "httpx>=0.27.0",
-    "ecdsa>=0.19.3",
 ]
 
 [dependency-groups]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.124.4
 uvicorn==0.33.0
 sqlalchemy==2.0.46
 psycopg2-binary==2.9.10
-python-jose==3.5.0
+PyJWT==2.10.1
 passlib==1.7.4
 openai==1.109.1
 python-multipart==0.0.27

--- a/uv.lock
+++ b/uv.lock
@@ -73,18 +73,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
-]
-
-[[package]]
 name = "fastapi"
 version = "0.124.4"
 source = { registry = "https://pypi.org/simple" }
@@ -343,15 +331,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
-]
-
-[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -451,6 +430,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -467,38 +455,12 @@ wheels = [
 ]
 
 [[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[[package]]
 name = "python-multipart"
 version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]
@@ -527,15 +489,6 @@ wheels = [
 ]
 
 [[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
 name = "sleeplab"
 version = "1.0.0"
 source = { virtual = "." }
@@ -545,7 +498,7 @@ dependencies = [
     { name = "openai" },
     { name = "passlib" },
     { name = "psycopg2-binary" },
-    { name = "python-jose" },
+    { name = "pyjwt" },
     { name = "python-multipart" },
     { name = "sqlalchemy" },
     { name = "uvicorn" },
@@ -564,7 +517,7 @@ requires-dist = [
     { name = "openai", specifier = "==1.109.1" },
     { name = "passlib", specifier = "==1.7.4" },
     { name = "psycopg2-binary", specifier = "==2.9.10" },
-    { name = "python-jose", specifier = "==3.5.0" },
+    { name = "pyjwt", specifier = "==2.10.1" },
     { name = "python-multipart", specifier = "==0.0.27" },
     { name = "sqlalchemy", specifier = "==2.0.46" },
     { name = "uvicorn", specifier = "==0.33.0" },


### PR DESCRIPTION
## Context

The backend CI check is currently failing on all open PRs due to an unsatisfiable dependency constraint introduced in commit `2e6b256`:

```
Because only ecdsa<=0.19.2 is available and your project depends on
ecdsa>=0.19.3, we can conclude that your project's requirements are
unsatisfiable.
```

`ecdsa>=0.19.3` doesn't exist on PyPI yet (latest is `0.19.2`), so `uv sync` fails during the Install dependencies step.

## What this does

Replaces `python-jose==3.5.0` with `PyJWT==2.10.1` and removes the `ecdsa>=0.19.3` constraint entirely.

`python-jose` pulls in `ecdsa` as a transitive dependency even though the app uses `ALGORITHM = "HS256"` exclusively — no EC crypto is ever exercised, so CVE-2025-54657 (the Minerva timing attack on P-256) never applied here. `PyJWT` has no `ecdsa` dependency and the `jwt.encode`/`jwt.decode` call signatures are identical for HS256, making the change in `api/auth.py` two lines.

## Changes

- `api/auth.py`: `from jose import JWTError, jwt` → `import jwt`; `except JWTError` → `except jwt.InvalidTokenError`
- `pyproject.toml`, `requirements.txt`, `api/requirements.txt`: swap `python-jose==3.5.0` for `PyJWT==2.10.1`, remove `ecdsa>=0.19.3`

## Note

JWT and auth infrastructure isn't an area I'm well versed in — happy to defer to your judgment on whether PyJWT is the right permanent choice here, or if there's a different direction you'd prefer. The goal was just to get CI green with the smallest possible change.

> **Heads up:** This should be merged before #42 (the licensing PR), since #42 currently depends on a broken dependency graph.