### PR TITLE
feat: add advanced trends overview

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -128,6 +128,32 @@ class DailyStat(BaseModel):
     session_id: str
 
 
+class OverviewDailyStat(BaseModel):
+    folder_date: date
+    session_id: str
+    ahi: Optional[float]
+    central_apnea_index: Optional[float]
+    obstructive_apnea_index: Optional[float]
+    hypopnea_index: Optional[float]
+    apnea_index: Optional[float]
+    arousal_index: Optional[float]
+    usage_hours: float
+    session_start_hour: Optional[float]
+    session_end_hour: Optional[float]
+    avg_pressure: Optional[float]
+    p95_pressure: Optional[float]
+    avg_leak: Optional[float]
+    large_leak_minutes: Optional[float]
+    avg_flow_lim: Optional[float]
+    avg_tidal_vol: Optional[float]
+    avg_min_vent: Optional[float]
+    avg_resp_rate: Optional[float]
+    min_spo2: Optional[float]
+    avg_spo2: Optional[float]
+    avg_pulse: Optional[float]
+    equipment_age_days: Optional[int]
+
+
 class SummaryStats(BaseModel):
     total_nights: int
     nights_with_data: int
@@ -136,3 +162,7 @@ class SummaryStats(BaseModel):
     avg_pressure: Optional[float]
     ahi_trend: List[DailyStat]
     event_breakdown: Dict
+
+
+class OverviewStats(BaseModel):
+    nights: List[OverviewDailyStat]

--- a/api/routers/stats.py
+++ b/api/routers/stats.py
@@ -1,12 +1,16 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 from sqlalchemy import text
 
 from ..auth import get_current_user
 from ..database import get_db
-from ..models import SummaryStats, DailyStat
+from ..models import SummaryStats, DailyStat, OverviewStats, OverviewDailyStat
 
 router = APIRouter()
+
+
+def _float_or_none(value):
+    return float(value) if value is not None else None
 
 
 @router.get("/summary", response_model=SummaryStats)
@@ -107,4 +111,160 @@ def get_summary(
         avg_pressure=avg_pressure,
         ahi_trend=ahi_trend,
         event_breakdown=event_breakdown,
+    )
+
+
+@router.get("/overview", response_model=OverviewStats)
+def get_overview(
+    days: int = Query(180, ge=7, le=3650),
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Long-range nightly trend data for the overview page.
+
+    Multi-block nights are grouped into one row. Event counts are normalized to
+    hourly indexes so they can be compared across nights of different lengths.
+    """
+    rows = db.execute(text("""
+        WITH night AS (
+            SELECT
+                folder_date,
+                (array_agg(id::text ORDER BY duration_seconds DESC))[1] AS session_id,
+                MIN(start_datetime) AS start_datetime,
+                MIN(start_datetime) + (SUM(duration_seconds) * INTERVAL '1 second') AS end_datetime,
+                SUM(duration_seconds) AS duration_seconds,
+                SUM(total_ahi_events) AS total_ahi_events,
+                SUM(central_apnea_count) AS central_apnea_count,
+                SUM(obstructive_apnea_count) AS obstructive_apnea_count,
+                SUM(hypopnea_count) AS hypopnea_count,
+                SUM(apnea_count) AS apnea_count,
+                SUM(COALESCE(arousal_count, 0)) AS arousal_count,
+                AVG(avg_pressure) AS avg_pressure,
+                MAX(p95_pressure) AS p95_pressure,
+                AVG(avg_leak) AS avg_leak,
+                AVG(avg_flow_lim) AS avg_flow_lim,
+                AVG(avg_tidal_vol) AS avg_tidal_vol,
+                AVG(avg_min_vent) AS avg_min_vent,
+                AVG(avg_resp_rate) AS avg_resp_rate,
+                AVG(avg_spo2) AS avg_spo2,
+                MIN(min_spo2) AS min_spo2
+            FROM sessions
+            WHERE user_id = CAST(:uid AS uuid)
+              AND duration_seconds >= 600
+              AND folder_date >= CURRENT_DATE - (:days * INTERVAL '1 day')
+            GROUP BY folder_date
+        ),
+        metric AS (
+            SELECT
+                s.folder_date,
+                ROUND((COUNT(*) FILTER (WHERE sm.leak >= 24) * 2.0 / 60.0)::numeric, 1) AS large_leak_minutes
+            FROM sessions s
+            JOIN session_metrics sm ON sm.session_id = s.id
+            WHERE s.user_id = CAST(:uid AS uuid)
+              AND s.duration_seconds >= 600
+              AND s.folder_date >= CURRENT_DATE - (:days * INTERVAL '1 day')
+            GROUP BY s.folder_date
+        ),
+        spo2 AS (
+            SELECT
+                s.folder_date,
+                AVG(ss.spo2) AS avg_spo2,
+                MIN(ss.spo2) AS min_spo2,
+                AVG(ss.pulse) AS avg_pulse
+            FROM sessions s
+            JOIN session_spo2 ss ON ss.session_id = s.id
+            WHERE s.user_id = CAST(:uid AS uuid)
+              AND s.duration_seconds >= 600
+              AND s.folder_date >= CURRENT_DATE - (:days * INTERVAL '1 day')
+            GROUP BY s.folder_date
+        ),
+        equipment AS (
+            SELECT
+                n.folder_date,
+                MAX(n.folder_date - eq.start_date) AS equipment_age_days
+            FROM night n
+            LEFT JOIN LATERAL (
+                SELECT DISTINCT ON (equipment_type)
+                    equipment_type,
+                    start_date
+                FROM user_equipment
+                WHERE user_id = CAST(:uid AS uuid)
+                  AND start_date <= n.folder_date
+                ORDER BY equipment_type, start_date DESC
+            ) eq ON TRUE
+            GROUP BY n.folder_date
+        )
+        SELECT
+            n.folder_date,
+            n.session_id,
+            CASE WHEN n.duration_seconds > 0
+                 THEN ROUND((n.total_ahi_events / (n.duration_seconds / 3600.0))::numeric, 2)
+                 ELSE NULL END AS ahi,
+            CASE WHEN n.duration_seconds > 0
+                 THEN ROUND((n.central_apnea_count / (n.duration_seconds / 3600.0))::numeric, 2)
+                 ELSE NULL END AS central_apnea_index,
+            CASE WHEN n.duration_seconds > 0
+                 THEN ROUND((n.obstructive_apnea_count / (n.duration_seconds / 3600.0))::numeric, 2)
+                 ELSE NULL END AS obstructive_apnea_index,
+            CASE WHEN n.duration_seconds > 0
+                 THEN ROUND((n.hypopnea_count / (n.duration_seconds / 3600.0))::numeric, 2)
+                 ELSE NULL END AS hypopnea_index,
+            CASE WHEN n.duration_seconds > 0
+                 THEN ROUND((n.apnea_count / (n.duration_seconds / 3600.0))::numeric, 2)
+                 ELSE NULL END AS apnea_index,
+            CASE WHEN n.duration_seconds > 0
+                 THEN ROUND((n.arousal_count / (n.duration_seconds / 3600.0))::numeric, 2)
+                 ELSE NULL END AS arousal_index,
+            ROUND((n.duration_seconds / 3600.0)::numeric, 2) AS usage_hours,
+            ROUND((EXTRACT(HOUR FROM n.start_datetime) + EXTRACT(MINUTE FROM n.start_datetime) / 60.0)::numeric, 2) AS session_start_hour,
+            ROUND((EXTRACT(HOUR FROM n.end_datetime) + EXTRACT(MINUTE FROM n.end_datetime) / 60.0)::numeric, 2) AS session_end_hour,
+            ROUND(n.avg_pressure::numeric, 2) AS avg_pressure,
+            ROUND(n.p95_pressure::numeric, 2) AS p95_pressure,
+            ROUND(n.avg_leak::numeric, 2) AS avg_leak,
+            m.large_leak_minutes,
+            ROUND(n.avg_flow_lim::numeric, 4) AS avg_flow_lim,
+            ROUND(n.avg_tidal_vol::numeric, 2) AS avg_tidal_vol,
+            ROUND(n.avg_min_vent::numeric, 2) AS avg_min_vent,
+            ROUND(n.avg_resp_rate::numeric, 2) AS avg_resp_rate,
+            COALESCE(sp.min_spo2, n.min_spo2) AS min_spo2,
+            ROUND(COALESCE(sp.avg_spo2, n.avg_spo2)::numeric, 1) AS avg_spo2,
+            ROUND(sp.avg_pulse::numeric, 1) AS avg_pulse,
+            e.equipment_age_days
+        FROM night n
+        LEFT JOIN metric m ON m.folder_date = n.folder_date
+        LEFT JOIN spo2 sp ON sp.folder_date = n.folder_date
+        LEFT JOIN equipment e ON e.folder_date = n.folder_date
+        ORDER BY n.folder_date
+    """), {"uid": current_user["id"], "days": days}).mappings().all()
+
+    return OverviewStats(
+        nights=[
+            OverviewDailyStat(
+                folder_date=row["folder_date"],
+                session_id=row["session_id"],
+                ahi=_float_or_none(row["ahi"]),
+                central_apnea_index=_float_or_none(row["central_apnea_index"]),
+                obstructive_apnea_index=_float_or_none(row["obstructive_apnea_index"]),
+                hypopnea_index=_float_or_none(row["hypopnea_index"]),
+                apnea_index=_float_or_none(row["apnea_index"]),
+                arousal_index=_float_or_none(row["arousal_index"]),
+                usage_hours=_float_or_none(row["usage_hours"]) or 0.0,
+                session_start_hour=_float_or_none(row["session_start_hour"]),
+                session_end_hour=_float_or_none(row["session_end_hour"]),
+                avg_pressure=_float_or_none(row["avg_pressure"]),
+                p95_pressure=_float_or_none(row["p95_pressure"]),
+                avg_leak=_float_or_none(row["avg_leak"]),
+                large_leak_minutes=_float_or_none(row["large_leak_minutes"]),
+                avg_flow_lim=_float_or_none(row["avg_flow_lim"]),
+                avg_tidal_vol=_float_or_none(row["avg_tidal_vol"]),
+                avg_min_vent=_float_or_none(row["avg_min_vent"]),
+                avg_resp_rate=_float_or_none(row["avg_resp_rate"]),
+                min_spo2=_float_or_none(row["min_spo2"]),
+                avg_spo2=_float_or_none(row["avg_spo2"]),
+                avg_pulse=_float_or_none(row["avg_pulse"]),
+                equipment_age_days=row["equipment_age_days"],
+            )
+            for row in rows
+        ]
     )

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -194,6 +194,36 @@ export interface DailyStat {
   session_id: string
 }
 
+export interface OverviewDailyStat {
+  folder_date: string
+  session_id: string
+  ahi: number | null
+  central_apnea_index: number | null
+  obstructive_apnea_index: number | null
+  hypopnea_index: number | null
+  apnea_index: number | null
+  arousal_index: number | null
+  usage_hours: number
+  session_start_hour: number | null
+  session_end_hour: number | null
+  avg_pressure: number | null
+  p95_pressure: number | null
+  avg_leak: number | null
+  large_leak_minutes: number | null
+  avg_flow_lim: number | null
+  avg_tidal_vol: number | null
+  avg_min_vent: number | null
+  avg_resp_rate: number | null
+  min_spo2: number | null
+  avg_spo2: number | null
+  avg_pulse: number | null
+  equipment_age_days: number | null
+}
+
+export interface OverviewStats {
+  nights: OverviewDailyStat[]
+}
+
 export interface AppConfig {
   display_tz: string
   machine_tz: string
@@ -326,6 +356,7 @@ function postForm<T>(path: string, formData: FormData) {
 
 export const api = {
   getSummary: () => get<SummaryStats>('/stats/summary'),
+  getOverviewStats: (days = 180) => get<OverviewStats>('/stats/overview', { days }),
   getAISummary: (days = 30) => get<AISummaryResponse>('/stats/ai-summary', { days }),
   getSessionAISummary: (sessionId: string) => get<SessionAISummaryResponse>(`/stats/sessions/${sessionId}/ai-summary`),
   getTrendAISummary: () => get<TrendAISummaryResponse>('/stats/trend-ai'),

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -156,6 +156,25 @@
     font: inherit;
   }
 
+  select {
+    color: var(--foreground);
+    background-color: var(--surface-strong);
+    border-color: var(--border);
+  }
+
+  select option,
+  select optgroup {
+    color: var(--foreground);
+    background-color: var(--surface-strong);
+  }
+
+  [data-theme='dark'] select,
+  [data-theme='dark'] select option,
+  [data-theme='dark'] select optgroup {
+    color: var(--foreground);
+    background-color: #1c2026;
+  }
+
   #root {
     min-height: 100vh;
   }

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -244,6 +244,11 @@ function formatMetricDelta(value: number | null | undefined, metric: TrendMetric
   return `${sign}${formatMetricValue(value, metric)}`
 }
 
+function roundsToZero(value: number, metric: TrendMetric) {
+  const precision = metric.precision ?? 1
+  return Number(value.toFixed(precision)) === 0
+}
+
 function formatClockHour(hour: number) {
   const normalized = ((hour % 24) + 24) % 24
   const wholeHours = Math.floor(normalized)
@@ -305,7 +310,9 @@ function MetricSummaryCards({ nights, metric }: { nights: OverviewDailyStat[]; m
 
   const changeLabel = summary.change == null
     ? 'Not enough history'
-    : `${formatMetricDelta(summary.change, metric)} vs prior 7 nights`
+    : roundsToZero(summary.change, metric)
+      ? 'No meaningful change'
+      : `${formatMetricDelta(summary.change, metric)} vs prior 7 nights`
 
   return (
     <div className="mb-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
@@ -594,8 +601,10 @@ export default function TrendsPage() {
                 className="h-11 min-w-56 rounded-full border border-[var(--border)] bg-[var(--surface-strong)] px-4 text-sm font-bold text-[var(--foreground)] outline-none focus:border-[var(--accent-border)]"
                 value={metricKey}
                 onChange={(event) => setMetricKey(event.target.value as MetricKey)}
-                aria-label="Select trend metric"
+                aria-label="Jump to any trend metric"
+                title="Jump to any metric"
               >
+                <option value={metricKey}>Jump to metric...</option>
                 {TREND_METRICS.map((option) => (
                   <option key={option.key} value={option.key}>{option.label}</option>
                 ))}

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -495,6 +495,17 @@ function formatMetricValue(value: number | null | undefined, metric: TrendMetric
   return metric.unit ? `${formatted} ${metric.unit}` : formatted
 }
 
+function formatMetricRange(low: number, high: number, metric: TrendMetric) {
+  if (metric.unit === 'clock') {
+    return `${formatClockHour(low)} / ${formatClockHour(high)}`
+  }
+
+  const precision = metric.precision ?? 1
+  const lowValue = low.toFixed(precision)
+  const highValue = high.toFixed(precision)
+  return metric.unit ? `${lowValue} / ${highValue} ${metric.unit}` : `${lowValue} / ${highValue}`
+}
+
 function formatMetricDelta(value: number | null | undefined, metric: TrendMetric) {
   if (value == null) return '-'
   const sign = value >= 0 ? '+' : ''
@@ -587,7 +598,7 @@ function MetricSummaryCards({ nights, metric }: { nights: OverviewDailyStat[]; m
       <div className="rounded-[16px] border border-[var(--border)] bg-[var(--surface-soft)] px-4 py-4">
         <p className="text-xs font-bold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">Low / High</p>
         <p className="mt-2 text-lg font-extrabold text-[var(--foreground)]">
-          {formatMetricValue(summary.lowest.value, metric)} / {formatMetricValue(summary.highest.value, metric)}
+          {formatMetricRange(summary.lowest.value, summary.highest.value, metric)}
         </p>
         <p className="mt-1 text-xs text-[var(--muted-foreground)]">
           {summary.lowest.night.folder_date} / {summary.highest.night.folder_date}

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { CartesianGrid, Line, LineChart, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 
-import type { SummaryStats, TrendAISummaryResponse } from '../api/client'
+import type { OverviewDailyStat, SummaryStats, TrendAISummaryResponse } from '../api/client'
 import { api } from '../api/client'
-import AHITrendChart from '../components/AHITrendChart'
 import GlossaryText from '../components/GlossaryText'
 import { Card, CardContent } from '../components/ui/card'
+import { Button } from '../components/ui/button'
 import { IMPORT_COMPLETED_EVENT } from '../lib/aiSummaryCache'
 
 const TREND_FLAG_COLORS = {
@@ -30,6 +32,96 @@ const TREND_DIRECTION_LABEL: Record<string, string> = {
   stable: 'Stable',
   worsening: 'Worsening',
   variable: 'Variable',
+}
+
+type MetricKey = keyof Pick<
+  OverviewDailyStat,
+  | 'ahi'
+  | 'central_apnea_index'
+  | 'obstructive_apnea_index'
+  | 'hypopnea_index'
+  | 'apnea_index'
+  | 'arousal_index'
+  | 'usage_hours'
+  | 'session_start_hour'
+  | 'session_end_hour'
+  | 'avg_pressure'
+  | 'p95_pressure'
+  | 'avg_leak'
+  | 'large_leak_minutes'
+  | 'avg_flow_lim'
+  | 'avg_tidal_vol'
+  | 'avg_min_vent'
+  | 'avg_resp_rate'
+  | 'min_spo2'
+  | 'avg_spo2'
+  | 'avg_pulse'
+  | 'equipment_age_days'
+>
+
+interface TrendMetric {
+  key: MetricKey
+  label: string
+  shortLabel: string
+  unit: string
+  domain?: [number | 'auto', number | 'auto']
+  referenceLines?: Array<{ value: number; label: string; color: string }>
+  precision?: number
+  secondaryKey?: MetricKey
+  secondaryLabel?: string
+}
+
+const TREND_METRICS: TrendMetric[] = [
+  {
+    key: 'ahi',
+    label: 'AHI',
+    shortLabel: 'AHI',
+    unit: 'events/hr',
+    referenceLines: [
+      { value: 5, label: '5', color: '#6AA136' },
+      { value: 15, label: '15', color: '#E9784B' },
+    ],
+    precision: 1,
+  },
+  { key: 'central_apnea_index', label: 'Central apnea index', shortLabel: 'CAI', unit: 'events/hr', precision: 1 },
+  { key: 'obstructive_apnea_index', label: 'Obstructive apnea index', shortLabel: 'OAI', unit: 'events/hr', precision: 1 },
+  { key: 'hypopnea_index', label: 'Hypopnea index', shortLabel: 'HI', unit: 'events/hr', precision: 1 },
+  { key: 'apnea_index', label: 'Apnea index', shortLabel: 'AI', unit: 'events/hr', precision: 1 },
+  { key: 'arousal_index', label: 'Arousal index', shortLabel: 'Arousal', unit: 'events/hr', precision: 1 },
+  { key: 'usage_hours', label: 'Usage', shortLabel: 'Usage', unit: 'hours', domain: [0, 'auto'], precision: 2 },
+  {
+    key: 'session_start_hour',
+    label: 'Session times',
+    shortLabel: 'Times',
+    unit: 'clock',
+    domain: [0, 24],
+    precision: 2,
+    secondaryKey: 'session_end_hour',
+    secondaryLabel: 'End',
+  },
+  { key: 'avg_pressure', label: 'Average pressure', shortLabel: 'Avg pressure', unit: 'cmH2O', precision: 1 },
+  { key: 'p95_pressure', label: '95th pressure', shortLabel: 'P95 pressure', unit: 'cmH2O', precision: 1 },
+  { key: 'avg_leak', label: 'Leak', shortLabel: 'Leak', unit: 'L/min', precision: 1 },
+  { key: 'large_leak_minutes', label: 'Large leak time', shortLabel: 'Large leak', unit: 'min', domain: [0, 'auto'], precision: 1 },
+  { key: 'avg_flow_lim', label: 'Flow limitation', shortLabel: 'Flow lim', unit: '', precision: 3 },
+  { key: 'avg_tidal_vol', label: 'Tidal volume', shortLabel: 'Tidal vol', unit: 'mL', precision: 0 },
+  { key: 'avg_min_vent', label: 'Minute ventilation', shortLabel: 'Min vent', unit: 'L/min', precision: 1 },
+  { key: 'avg_resp_rate', label: 'Respiratory rate', shortLabel: 'Resp rate', unit: 'breaths/min', precision: 1 },
+  { key: 'min_spo2', label: 'SpO2 minimum', shortLabel: 'Min SpO2', unit: '%', domain: [70, 100], precision: 0 },
+  { key: 'avg_spo2', label: 'SpO2 average', shortLabel: 'Avg SpO2', unit: '%', domain: [70, 100], precision: 1 },
+  { key: 'avg_pulse', label: 'Pulse', shortLabel: 'Pulse', unit: 'bpm', precision: 0 },
+  { key: 'equipment_age_days', label: 'Equipment age', shortLabel: 'Equipment', unit: 'days', domain: [0, 'auto'], precision: 0 },
+]
+
+const RANGE_OPTIONS = [
+  { label: '90D', days: 90 },
+  { label: '180D', days: 180 },
+  { label: '1Y', days: 365 },
+  { label: 'All', days: 3650 },
+]
+
+function getMetric(key: MetricKey) {
+  return TREND_METRICS.find((metric) => metric.key === key) ?? TREND_METRICS[0]
 }
 
 function TrendAICard() {
@@ -111,16 +203,196 @@ function humanizeEventType(eventType: string) {
     .join(' ')
 }
 
+function formatMetricValue(value: number | null | undefined, metric: TrendMetric) {
+  if (value == null) return '-'
+  if (metric.unit === 'clock') return formatClockHour(value)
+  const precision = metric.precision ?? 1
+  const formatted = value.toFixed(precision)
+  return metric.unit ? `${formatted} ${metric.unit}` : formatted
+}
+
+function formatClockHour(hour: number) {
+  const normalized = ((hour % 24) + 24) % 24
+  const wholeHours = Math.floor(normalized)
+  const minutes = Math.round((normalized - wholeHours) * 60)
+  const displayHours = minutes === 60 ? (wholeHours + 1) % 24 : wholeHours
+  const displayMinutes = minutes === 60 ? 0 : minutes
+  const suffix = displayHours >= 12 ? 'PM' : 'AM'
+  const hour12 = displayHours % 12 || 12
+  return `${hour12}:${String(displayMinutes).padStart(2, '0')} ${suffix}`
+}
+
+function getActiveSessionId(payload: unknown) {
+  if (!payload || typeof payload !== 'object' || !('activePayload' in payload)) {
+    return null
+  }
+  const activePayload = (payload as { activePayload?: Array<{ payload?: { sessionId?: unknown } }> }).activePayload
+  const sessionId = activePayload?.[0]?.payload?.sessionId
+  return typeof sessionId === 'string' ? sessionId : null
+}
+
+function OverviewChart({
+  nights,
+  metric,
+}: {
+  nights: OverviewDailyStat[]
+  metric: TrendMetric
+}) {
+  const navigate = useNavigate()
+  const data = nights.map((night) => ({
+    ...night,
+    date: night.folder_date,
+    primary: night[metric.key],
+    secondary: metric.secondaryKey ? night[metric.secondaryKey] : null,
+  }))
+
+  return (
+    <Card id="long-range-overview">
+      <CardContent className="px-4 pb-5 pt-5 sm:px-6 sm:pt-6">
+        <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-sm font-bold text-[var(--foreground)]">{metric.label}</p>
+            <p className="text-sm text-[var(--muted-foreground)]">{nights.length} nights in the selected range</p>
+          </div>
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--accent)]">{metric.unit || 'Index'}</p>
+        </div>
+        <ResponsiveContainer width="100%" height={320}>
+          <LineChart
+            data={data}
+            margin={{ top: 12, right: 16, bottom: 0, left: 0 }}
+            onClick={(payload) => {
+              const sessionId = getActiveSessionId(payload)
+              if (sessionId) {
+                navigate(`/sessions/${sessionId}`)
+              }
+            }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--neutral-200)" />
+            <XAxis
+              dataKey="date"
+              tick={{ fill: 'var(--muted-foreground)', fontSize: 11 }}
+              tickFormatter={(value: string) => value.slice(5)}
+              minTickGap={24}
+            />
+            <YAxis
+              tick={{ fill: 'var(--muted-foreground)', fontSize: 11 }}
+              domain={metric.domain ?? [0, 'auto']}
+              tickFormatter={(value) => metric.unit === 'clock' ? formatClockHour(Number(value)).replace(':00 ', ' ') : String(value)}
+              width={54}
+            />
+            <Tooltip
+              contentStyle={{
+                background: 'var(--popover-surface)',
+                border: '1px solid var(--border)',
+                borderRadius: 14,
+                color: 'var(--foreground)',
+              }}
+              labelStyle={{ color: 'var(--foreground)' }}
+              formatter={(value, name) => {
+                const label = name === 'secondary' ? (metric.secondaryLabel ?? 'End') : metric.shortLabel
+                return [formatMetricValue(typeof value === 'number' ? value : null, metric), label]
+              }}
+            />
+            {metric.referenceLines?.map((line) => (
+              <ReferenceLine
+                key={line.value}
+                y={line.value}
+                stroke={line.color}
+                strokeDasharray="4 4"
+                label={{ value: line.label, fill: line.color, fontSize: 10 }}
+              />
+            ))}
+            <Line
+              type="monotone"
+              dataKey="primary"
+              name={metric.shortLabel}
+              stroke="#5251A7"
+              dot={false}
+              strokeWidth={2}
+              connectNulls
+            />
+            {metric.secondaryKey ? (
+              <Line
+                type="monotone"
+                dataKey="secondary"
+                name={metric.secondaryLabel ?? 'End'}
+                stroke="#6AA136"
+                dot={false}
+                strokeWidth={2}
+                connectNulls
+              />
+            ) : null}
+          </LineChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  )
+}
+
+function RecentOverviewTable({ nights, metric }: { nights: OverviewDailyStat[]; metric: TrendMetric }) {
+  const recent = nights.slice(-10).reverse()
+
+  return (
+    <Card id="overview-table">
+      <CardContent className="px-0 pb-2 pt-5 sm:pt-6">
+        <div className="px-5 sm:px-6">
+          <p className="text-sm font-bold text-[var(--foreground)]">Recent nights</p>
+          <p className="mt-1 text-sm text-[var(--muted-foreground)]">Latest values for the selected trend.</p>
+        </div>
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full min-w-[560px] border-collapse text-sm">
+            <thead>
+              <tr className="border-y border-[var(--border)] bg-[var(--surface-soft)] text-left text-xs font-bold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
+                <th className="px-5 py-3 sm:px-6">Date</th>
+                <th className="px-5 py-3 sm:px-6">{metric.shortLabel}</th>
+                <th className="px-5 py-3 sm:px-6">AHI</th>
+                <th className="px-5 py-3 sm:px-6">Usage</th>
+                <th className="px-5 py-3 sm:px-6">Leak</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recent.map((night) => (
+                <tr key={night.folder_date} className="border-b border-[var(--border)] last:border-b-0">
+                  <td className="px-5 py-3 font-bold text-[var(--foreground)] sm:px-6">{night.folder_date}</td>
+                  <td className="px-5 py-3 text-[var(--foreground)] sm:px-6">
+                    {formatMetricValue(night[metric.key], metric)}
+                    {metric.secondaryKey ? (
+                      <span className="ml-2 text-[var(--muted-foreground)]">
+                        to {formatMetricValue(night[metric.secondaryKey], metric)}
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="px-5 py-3 text-[var(--muted-foreground)] sm:px-6">{formatMetricValue(night.ahi, getMetric('ahi'))}</td>
+                  <td className="px-5 py-3 text-[var(--muted-foreground)] sm:px-6">{night.usage_hours.toFixed(2)} hours</td>
+                  <td className="px-5 py-3 text-[var(--muted-foreground)] sm:px-6">{formatMetricValue(night.avg_leak, getMetric('avg_leak'))}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
 export default function TrendsPage() {
   const [summary, setSummary] = useState<SummaryStats | null>(null)
+  const [overview, setOverview] = useState<OverviewDailyStat[]>([])
+  const [rangeDays, setRangeDays] = useState(180)
+  const [metricKey, setMetricKey] = useState<MetricKey>('ahi')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const metric = getMetric(metricKey)
 
   useEffect(() => {
     async function loadTrends() {
       try {
-        const data = await api.getSummary()
+        const [data, overviewData] = await Promise.all([
+          api.getSummary(),
+          api.getOverviewStats(rangeDays),
+        ])
         setSummary(data)
+        setOverview(overviewData.nights)
         setError(null)
       } catch (err) {
         setError(String(err))
@@ -138,7 +410,7 @@ export default function TrendsPage() {
 
     window.addEventListener(IMPORT_COMPLETED_EVENT, handleImportCompleted)
     return () => window.removeEventListener(IMPORT_COMPLETED_EVENT, handleImportCompleted)
-  }, [])
+  }, [rangeDays])
 
   if (loading) {
     return <div className="rounded-[22px] border border-[var(--border)] bg-[var(--surface-strong)] p-10 text-center text-[var(--muted-foreground)]">Loading trends...</div>
@@ -179,9 +451,73 @@ export default function TrendsPage() {
         </Card>
       </div>
 
-      <div id="ahi-trend">
-        <AHITrendChart trend={summary.ahi_trend} />
-      </div>
+      <Card>
+        <CardContent className="px-4 pb-5 pt-5 sm:px-6 sm:pt-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <p className="text-sm font-bold text-[var(--foreground)]">Long-range overview</p>
+              <p className="mt-1 text-sm text-[var(--muted-foreground)]">Pick a range and metric to scan nightly therapy patterns over time.</p>
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+              <div className="grid grid-cols-4 rounded-full border border-[var(--border)] bg-[var(--surface-soft)] p-1">
+                {RANGE_OPTIONS.map((option) => (
+                  <button
+                    key={option.days}
+                    type="button"
+                    className={`rounded-full px-3 py-2 text-sm font-bold transition ${
+                      rangeDays === option.days
+                        ? 'bg-[var(--surface-strong)] text-[var(--accent)]'
+                        : 'text-[var(--muted-foreground)] hover:text-[var(--foreground)]'
+                    }`}
+                    onClick={() => {
+                      setLoading(true)
+                      setRangeDays(option.days)
+                    }}
+                    aria-pressed={rangeDays === option.days}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+              <select
+                className="h-11 min-w-56 rounded-full border border-[var(--border)] bg-[var(--surface-strong)] px-4 text-sm font-bold text-[var(--foreground)] outline-none focus:border-[var(--accent-border)]"
+                value={metricKey}
+                onChange={(event) => setMetricKey(event.target.value as MetricKey)}
+                aria-label="Select trend metric"
+              >
+                {TREND_METRICS.map((option) => (
+                  <option key={option.key} value={option.key}>{option.label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {TREND_METRICS.slice(0, 12).map((option) => (
+              <Button
+                key={option.key}
+                variant={metricKey === option.key ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setMetricKey(option.key)}
+              >
+                {option.shortLabel}
+              </Button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {overview.length > 0 ? (
+        <>
+          <OverviewChart nights={overview} metric={metric} />
+          <RecentOverviewTable nights={overview} metric={metric} />
+        </>
+      ) : (
+        <Card>
+          <CardContent className="px-6 pb-6 pt-7 text-center text-sm text-[var(--muted-foreground)]">
+            No trend rows are available for this range.
+          </CardContent>
+        </Card>
+      )}
 
       <Card id="event-breakdown">
         <CardContent className="px-6 pb-6 pt-7">

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { CartesianGrid, Line, LineChart, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import { Bar, CartesianGrid, ComposedChart, Line, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 
 import type { OverviewDailyStat, SummaryStats, TrendAISummaryResponse } from '../api/client'
 import { api } from '../api/client'
@@ -64,6 +64,7 @@ interface TrendMetric {
   label: string
   shortLabel: string
   unit: string
+  chart: 'line' | 'bar'
   domain?: [number | 'auto', number | 'auto']
   referenceLines?: Array<{ value: number; label: string; color: string }>
   precision?: number
@@ -77,41 +78,66 @@ const TREND_METRICS: TrendMetric[] = [
     label: 'AHI',
     shortLabel: 'AHI',
     unit: 'events/hr',
+    chart: 'line',
     referenceLines: [
       { value: 5, label: '5', color: '#6AA136' },
       { value: 15, label: '15', color: '#E9784B' },
     ],
     precision: 1,
   },
-  { key: 'central_apnea_index', label: 'Central apnea index', shortLabel: 'CAI', unit: 'events/hr', precision: 1 },
-  { key: 'obstructive_apnea_index', label: 'Obstructive apnea index', shortLabel: 'OAI', unit: 'events/hr', precision: 1 },
-  { key: 'hypopnea_index', label: 'Hypopnea index', shortLabel: 'HI', unit: 'events/hr', precision: 1 },
-  { key: 'apnea_index', label: 'Apnea index', shortLabel: 'AI', unit: 'events/hr', precision: 1 },
-  { key: 'arousal_index', label: 'Arousal index', shortLabel: 'Arousal', unit: 'events/hr', precision: 1 },
-  { key: 'usage_hours', label: 'Usage', shortLabel: 'Usage', unit: 'hours', domain: [0, 'auto'], precision: 2 },
+  { key: 'central_apnea_index', label: 'Central apnea index', shortLabel: 'CAI', unit: 'events/hr', chart: 'bar', precision: 1 },
+  { key: 'obstructive_apnea_index', label: 'Obstructive apnea index', shortLabel: 'OAI', unit: 'events/hr', chart: 'bar', precision: 1 },
+  { key: 'hypopnea_index', label: 'Hypopnea index', shortLabel: 'HI', unit: 'events/hr', chart: 'bar', precision: 1 },
+  { key: 'apnea_index', label: 'Apnea index', shortLabel: 'AI', unit: 'events/hr', chart: 'bar', precision: 1 },
+  { key: 'arousal_index', label: 'Arousal index', shortLabel: 'Arousal', unit: 'events/hr', chart: 'bar', precision: 1 },
+  { key: 'usage_hours', label: 'Usage', shortLabel: 'Usage', unit: 'hours', chart: 'line', domain: [0, 'auto'], precision: 2 },
   {
     key: 'session_start_hour',
     label: 'Session times',
     shortLabel: 'Times',
     unit: 'clock',
+    chart: 'line',
     domain: [0, 24],
     precision: 2,
     secondaryKey: 'session_end_hour',
     secondaryLabel: 'End',
   },
-  { key: 'avg_pressure', label: 'Average pressure', shortLabel: 'Avg pressure', unit: 'cmH2O', precision: 1 },
-  { key: 'p95_pressure', label: '95th pressure', shortLabel: 'P95 pressure', unit: 'cmH2O', precision: 1 },
-  { key: 'avg_leak', label: 'Leak', shortLabel: 'Leak', unit: 'L/min', precision: 1 },
-  { key: 'large_leak_minutes', label: 'Large leak time', shortLabel: 'Large leak', unit: 'min', domain: [0, 'auto'], precision: 1 },
-  { key: 'avg_flow_lim', label: 'Flow limitation', shortLabel: 'Flow lim', unit: '', precision: 3 },
-  { key: 'avg_tidal_vol', label: 'Tidal volume', shortLabel: 'Tidal vol', unit: 'mL', precision: 0 },
-  { key: 'avg_min_vent', label: 'Minute ventilation', shortLabel: 'Min vent', unit: 'L/min', precision: 1 },
-  { key: 'avg_resp_rate', label: 'Respiratory rate', shortLabel: 'Resp rate', unit: 'breaths/min', precision: 1 },
-  { key: 'min_spo2', label: 'SpO2 minimum', shortLabel: 'Min SpO2', unit: '%', domain: [70, 100], precision: 0 },
-  { key: 'avg_spo2', label: 'SpO2 average', shortLabel: 'Avg SpO2', unit: '%', domain: [70, 100], precision: 1 },
-  { key: 'avg_pulse', label: 'Pulse', shortLabel: 'Pulse', unit: 'bpm', precision: 0 },
-  { key: 'equipment_age_days', label: 'Equipment age', shortLabel: 'Equipment', unit: 'days', domain: [0, 'auto'], precision: 0 },
+  { key: 'avg_pressure', label: 'Average pressure', shortLabel: 'Avg pressure', unit: 'cmH2O', chart: 'line', precision: 1 },
+  { key: 'p95_pressure', label: '95th pressure', shortLabel: 'P95 pressure', unit: 'cmH2O', chart: 'line', precision: 1 },
+  { key: 'avg_leak', label: 'Leak', shortLabel: 'Leak', unit: 'L/min', chart: 'line', precision: 1 },
+  { key: 'large_leak_minutes', label: 'Large leak time', shortLabel: 'Large leak', unit: 'min', chart: 'bar', domain: [0, 'auto'], precision: 1 },
+  { key: 'avg_flow_lim', label: 'Flow limitation', shortLabel: 'Flow lim', unit: '', chart: 'line', precision: 3 },
+  { key: 'avg_tidal_vol', label: 'Tidal volume', shortLabel: 'Tidal vol', unit: 'mL', chart: 'line', precision: 0 },
+  { key: 'avg_min_vent', label: 'Minute ventilation', shortLabel: 'Min vent', unit: 'L/min', chart: 'line', precision: 1 },
+  { key: 'avg_resp_rate', label: 'Respiratory rate', shortLabel: 'Resp rate', unit: 'breaths/min', chart: 'line', precision: 1 },
+  { key: 'min_spo2', label: 'SpO2 minimum', shortLabel: 'Min SpO2', unit: '%', chart: 'line', domain: [70, 100], precision: 0 },
+  { key: 'avg_spo2', label: 'SpO2 average', shortLabel: 'Avg SpO2', unit: '%', chart: 'line', domain: [70, 100], precision: 1 },
+  { key: 'avg_pulse', label: 'Pulse', shortLabel: 'Pulse', unit: 'bpm', chart: 'line', precision: 0 },
+  { key: 'equipment_age_days', label: 'Equipment age', shortLabel: 'Equipment', unit: 'days', chart: 'line', domain: [0, 'auto'], precision: 0 },
 ]
+
+const TREND_METRIC_GROUPS = [
+  {
+    label: 'Events',
+    keys: ['ahi', 'central_apnea_index', 'obstructive_apnea_index', 'hypopnea_index', 'apnea_index', 'arousal_index'],
+  },
+  {
+    label: 'Therapy',
+    keys: ['usage_hours', 'session_start_hour', 'avg_pressure', 'p95_pressure', 'avg_leak', 'large_leak_minutes'],
+  },
+  {
+    label: 'Breathing',
+    keys: ['avg_flow_lim', 'avg_tidal_vol', 'avg_min_vent', 'avg_resp_rate'],
+  },
+  {
+    label: 'Oximetry',
+    keys: ['min_spo2', 'avg_spo2', 'avg_pulse'],
+  },
+  {
+    label: 'Equipment',
+    keys: ['equipment_age_days'],
+  },
+] satisfies Array<{ label: string; keys: MetricKey[] }>
 
 const RANGE_OPTIONS = [
   { label: '90D', days: 90 },
@@ -211,6 +237,13 @@ function formatMetricValue(value: number | null | undefined, metric: TrendMetric
   return metric.unit ? `${formatted} ${metric.unit}` : formatted
 }
 
+function formatMetricDelta(value: number | null | undefined, metric: TrendMetric) {
+  if (value == null) return '-'
+  const sign = value >= 0 ? '+' : ''
+  if (metric.unit === 'clock') return `${sign}${value.toFixed(2)} hr`
+  return `${sign}${formatMetricValue(value, metric)}`
+}
+
 function formatClockHour(hour: number) {
   const normalized = ((hour % 24) + 24) % 24
   const wholeHours = Math.floor(normalized)
@@ -229,6 +262,79 @@ function getActiveSessionId(payload: unknown) {
   const activePayload = (payload as { activePayload?: Array<{ payload?: { sessionId?: unknown } }> }).activePayload
   const sessionId = activePayload?.[0]?.payload?.sessionId
   return typeof sessionId === 'string' ? sessionId : null
+}
+
+function metricNumber(value: OverviewDailyStat[MetricKey]) {
+  return typeof value === 'number' ? value : null
+}
+
+function calculateMetricSummary(nights: OverviewDailyStat[], metric: TrendMetric) {
+  const points = nights
+    .map((night) => ({ night, value: metricNumber(night[metric.key]) }))
+    .filter((point): point is { night: OverviewDailyStat; value: number } => point.value != null)
+
+  if (points.length === 0) {
+    return null
+  }
+
+  const average = points.reduce((sum, point) => sum + point.value, 0) / points.length
+  const latest = points[points.length - 1]
+  const lowest = points.reduce((best, point) => point.value < best.value ? point : best, points[0])
+  const highest = points.reduce((best, point) => point.value > best.value ? point : best, points[0])
+  const recent = points.slice(-7)
+  const previous = points.slice(Math.max(0, points.length - 14), Math.max(0, points.length - 7))
+  const recentAverage = recent.reduce((sum, point) => sum + point.value, 0) / recent.length
+  const previousAverage = previous.length > 0
+    ? previous.reduce((sum, point) => sum + point.value, 0) / previous.length
+    : null
+  const change = previousAverage == null ? null : recentAverage - previousAverage
+
+  return { average, latest, lowest, highest, change }
+}
+
+function MetricSummaryCards({ nights, metric }: { nights: OverviewDailyStat[]; metric: TrendMetric }) {
+  const summary = calculateMetricSummary(nights, metric)
+
+  if (!summary) {
+    return (
+      <div className="mb-5 rounded-[16px] border border-[var(--border)] bg-[var(--surface-soft)] px-4 py-4 text-sm text-[var(--muted-foreground)]">
+        No values are available for this metric in the selected range.
+      </div>
+    )
+  }
+
+  const changeLabel = summary.change == null
+    ? 'Not enough history'
+    : `${formatMetricDelta(summary.change, metric)} vs prior 7 nights`
+
+  return (
+    <div className="mb-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="rounded-[16px] border border-[var(--border)] bg-[var(--surface-soft)] px-4 py-4">
+        <p className="text-xs font-bold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">Latest</p>
+        <p className="mt-2 text-lg font-extrabold text-[var(--foreground)]">{formatMetricValue(summary.latest.value, metric)}</p>
+        <p className="mt-1 text-xs text-[var(--muted-foreground)]">{summary.latest.night.folder_date}</p>
+      </div>
+      <div className="rounded-[16px] border border-[var(--border)] bg-[var(--surface-soft)] px-4 py-4">
+        <p className="text-xs font-bold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">Average</p>
+        <p className="mt-2 text-lg font-extrabold text-[var(--foreground)]">{formatMetricValue(summary.average, metric)}</p>
+        <p className="mt-1 text-xs text-[var(--muted-foreground)]">{nights.length} nights selected</p>
+      </div>
+      <div className="rounded-[16px] border border-[var(--border)] bg-[var(--surface-soft)] px-4 py-4">
+        <p className="text-xs font-bold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">Low / High</p>
+        <p className="mt-2 text-lg font-extrabold text-[var(--foreground)]">
+          {formatMetricValue(summary.lowest.value, metric)} / {formatMetricValue(summary.highest.value, metric)}
+        </p>
+        <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+          {summary.lowest.night.folder_date} / {summary.highest.night.folder_date}
+        </p>
+      </div>
+      <div className="rounded-[16px] border border-[var(--border)] bg-[var(--surface-soft)] px-4 py-4">
+        <p className="text-xs font-bold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">Recent shift</p>
+        <p className="mt-2 text-lg font-extrabold text-[var(--foreground)]">{changeLabel}</p>
+        <p className="mt-1 text-xs text-[var(--muted-foreground)]">7-night average comparison</p>
+      </div>
+    </div>
+  )
 }
 
 function OverviewChart({
@@ -256,8 +362,9 @@ function OverviewChart({
           </div>
           <p className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--accent)]">{metric.unit || 'Index'}</p>
         </div>
+        <MetricSummaryCards nights={nights} metric={metric} />
         <ResponsiveContainer width="100%" height={320}>
-          <LineChart
+          <ComposedChart
             data={data}
             margin={{ top: 12, right: 16, bottom: 0, left: 0 }}
             onClick={(payload) => {
@@ -302,15 +409,19 @@ function OverviewChart({
                 label={{ value: line.label, fill: line.color, fontSize: 10 }}
               />
             ))}
-            <Line
-              type="monotone"
-              dataKey="primary"
-              name={metric.shortLabel}
-              stroke="#5251A7"
-              dot={false}
-              strokeWidth={2}
-              connectNulls
-            />
+            {metric.chart === 'bar' ? (
+              <Bar dataKey="primary" name={metric.shortLabel} fill="#5251A7" radius={[6, 6, 0, 0]} maxBarSize={28} />
+            ) : (
+              <Line
+                type="monotone"
+                dataKey="primary"
+                name={metric.shortLabel}
+                stroke="#5251A7"
+                dot={false}
+                strokeWidth={2}
+                connectNulls
+              />
+            )}
             {metric.secondaryKey ? (
               <Line
                 type="monotone"
@@ -322,7 +433,7 @@ function OverviewChart({
                 connectNulls
               />
             ) : null}
-          </LineChart>
+          </ComposedChart>
         </ResponsiveContainer>
       </CardContent>
     </Card>
@@ -491,16 +602,27 @@ export default function TrendsPage() {
               </select>
             </div>
           </div>
-          <div className="mt-4 flex flex-wrap gap-2">
-            {TREND_METRICS.slice(0, 12).map((option) => (
-              <Button
-                key={option.key}
-                variant={metricKey === option.key ? 'default' : 'outline'}
-                size="sm"
-                onClick={() => setMetricKey(option.key)}
-              >
-                {option.shortLabel}
-              </Button>
+          <div className="mt-5 grid gap-4 lg:grid-cols-[1.1fr_1fr] xl:grid-cols-[1.1fr_1fr_0.75fr]">
+            {TREND_METRIC_GROUPS.map((group) => (
+              <div key={group.label} className="min-w-0">
+                <p className="mb-2 text-xs font-bold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">{group.label}</p>
+                <div className="flex flex-wrap gap-2">
+                  {group.keys.map((key) => {
+                    const option = getMetric(key)
+                    return (
+                      <Button
+                        key={option.key}
+                        variant={metricKey === option.key ? 'default' : 'outline'}
+                        size="sm"
+                        className="h-8 px-3 text-xs sm:h-9 sm:text-sm"
+                        onClick={() => setMetricKey(option.key)}
+                      >
+                        {option.shortLabel}
+                      </Button>
+                    )
+                  })}
+                </div>
+              </div>
             ))}
           </div>
         </CardContent>

--- a/frontend/src/pages/Trends.tsx
+++ b/frontend/src/pages/Trends.tsx
@@ -5,6 +5,7 @@ import { Bar, CartesianGrid, ComposedChart, Line, ReferenceLine, ResponsiveConta
 import type { OverviewDailyStat, SummaryStats, TrendAISummaryResponse } from '../api/client'
 import { api } from '../api/client'
 import GlossaryText from '../components/GlossaryText'
+import InfoPopover from '../components/InfoPopover'
 import { Card, CardContent } from '../components/ui/card'
 import { Button } from '../components/ui/button'
 import { IMPORT_COMPLETED_EVENT } from '../lib/aiSummaryCache'
@@ -65,6 +66,12 @@ interface TrendMetric {
   shortLabel: string
   unit: string
   chart: 'line' | 'bar'
+  guidance: {
+    range: string
+    detail: string
+    source: string
+    sourceUrl: string
+  }
   domain?: [number | 'auto', number | 'auto']
   referenceLines?: Array<{ value: number; label: string; color: string }>
   precision?: number
@@ -79,41 +86,292 @@ const TREND_METRICS: TrendMetric[] = [
     shortLabel: 'AHI',
     unit: 'events/hr',
     chart: 'line',
+    guidance: {
+      range: 'Under 5 events/hr is generally considered normal; 5-14 mild, 15-29 moderate, and 30+ severe.',
+      detail: 'AHI is the combined count of apneas and hypopneas per hour. On treatment, many people aim to keep residual AHI below 5 unless their clinician gives a different target.',
+      source: 'Cleveland Clinic',
+      sourceUrl: 'https://my.clevelandclinic.org/health/articles/apnea-hypopnea-index-ahi',
+    },
     referenceLines: [
       { value: 5, label: '5', color: '#6AA136' },
       { value: 15, label: '15', color: '#E9784B' },
     ],
     precision: 1,
   },
-  { key: 'central_apnea_index', label: 'Central apnea index', shortLabel: 'CAI', unit: 'events/hr', chart: 'bar', precision: 1 },
-  { key: 'obstructive_apnea_index', label: 'Obstructive apnea index', shortLabel: 'OAI', unit: 'events/hr', chart: 'bar', precision: 1 },
-  { key: 'hypopnea_index', label: 'Hypopnea index', shortLabel: 'HI', unit: 'events/hr', chart: 'bar', precision: 1 },
-  { key: 'apnea_index', label: 'Apnea index', shortLabel: 'AI', unit: 'events/hr', chart: 'bar', precision: 1 },
-  { key: 'arousal_index', label: 'Arousal index', shortLabel: 'Arousal', unit: 'events/hr', chart: 'bar', precision: 1 },
-  { key: 'usage_hours', label: 'Usage', shortLabel: 'Usage', unit: 'hours', chart: 'line', domain: [0, 'auto'], precision: 2 },
+  {
+    key: 'central_apnea_index',
+    label: 'Central apnea index',
+    shortLabel: 'CAI',
+    unit: 'events/hr',
+    chart: 'bar',
+    precision: 1,
+    guidance: {
+      range: 'A central apnea/hypopnea index around 5 or more per hour is commonly used as a clinical flag for central sleep apnea patterns.',
+      detail: 'Small numbers can occur on PAP. Persistent or rising central events are worth discussing with a sleep clinician, especially if they make up a large share of AHI.',
+      source: 'AASM / Cleveland Clinic',
+      sourceUrl: 'https://pubmed.ncbi.nlm.nih.gov/40820608/',
+    },
+  },
+  {
+    key: 'obstructive_apnea_index',
+    label: 'Obstructive apnea index',
+    shortLabel: 'OAI',
+    unit: 'events/hr',
+    chart: 'bar',
+    precision: 1,
+    guidance: {
+      range: 'Lower is better. AHI under 5 events/hr is the usual treated-breathing benchmark, and obstructive events are one component of that total.',
+      detail: 'If OAI is the main contributor to AHI, it can point toward residual airway obstruction, mask leak, position, or pressure settings to review.',
+      source: 'Cleveland Clinic',
+      sourceUrl: 'https://my.clevelandclinic.org/health/articles/apnea-hypopnea-index-ahi',
+    },
+  },
+  {
+    key: 'hypopnea_index',
+    label: 'Hypopnea index',
+    shortLabel: 'HI',
+    unit: 'events/hr',
+    chart: 'bar',
+    precision: 1,
+    guidance: {
+      range: 'Lower is better. Hypopneas count toward AHI, where under 5 events/hr is generally considered normal.',
+      detail: 'A higher hypopnea index means partial breathing reductions are driving more of the nightly AHI.',
+      source: 'Cleveland Clinic',
+      sourceUrl: 'https://my.clevelandclinic.org/health/articles/apnea-hypopnea-index-ahi',
+    },
+  },
+  {
+    key: 'apnea_index',
+    label: 'Apnea index',
+    shortLabel: 'AI',
+    unit: 'events/hr',
+    chart: 'bar',
+    precision: 1,
+    guidance: {
+      range: 'Lower is better. This is one component of AHI, and AHI under 5 events/hr is the usual normal benchmark.',
+      detail: 'Use this beside CAI/OAI to see whether full pauses are central, obstructive, or mixed in pattern.',
+      source: 'Cleveland Clinic',
+      sourceUrl: 'https://my.clevelandclinic.org/health/articles/apnea-hypopnea-index-ahi',
+    },
+  },
+  {
+    key: 'arousal_index',
+    label: 'Arousal index',
+    shortLabel: 'Arousal',
+    unit: 'events/hr',
+    chart: 'bar',
+    precision: 1,
+    guidance: {
+      range: 'There is not one universal home-CPAP cutoff for a good arousal index.',
+      detail: 'Watch the trend and context. Arousals can fragment sleep even when AHI looks controlled, but interpretation depends on how events were scored.',
+      source: 'AASM',
+      sourceUrl: 'https://pmc.ncbi.nlm.nih.gov/articles/PMC5337595/',
+    },
+  },
+  {
+    key: 'usage_hours',
+    label: 'Usage',
+    shortLabel: 'Usage',
+    unit: 'hours',
+    chart: 'line',
+    domain: [0, 'auto'],
+    precision: 2,
+    guidance: {
+      range: 'A common adherence benchmark is at least 4 hours per night on at least 70% of nights.',
+      detail: 'More full-night use is usually more informative than meeting the minimum insurance-style threshold.',
+      source: 'AASM',
+      sourceUrl: 'https://aasm.org/resources/pdf/responsetocmsjan.pdf',
+    },
+  },
   {
     key: 'session_start_hour',
     label: 'Session times',
     shortLabel: 'Times',
     unit: 'clock',
     chart: 'line',
+    guidance: {
+      range: 'There is no universal good bedtime or wake time in CPAP data.',
+      detail: 'Look for consistency, short nights, or schedule changes that line up with AHI, leak, oxygen, or daytime symptoms.',
+      source: 'SleepLab trend context',
+      sourceUrl: 'https://my.clevelandclinic.org/health/articles/apnea-hypopnea-index-ahi',
+    },
     domain: [0, 24],
     precision: 2,
     secondaryKey: 'session_end_hour',
     secondaryLabel: 'End',
   },
-  { key: 'avg_pressure', label: 'Average pressure', shortLabel: 'Avg pressure', unit: 'cmH2O', chart: 'line', precision: 1 },
-  { key: 'p95_pressure', label: '95th pressure', shortLabel: 'P95 pressure', unit: 'cmH2O', chart: 'line', precision: 1 },
-  { key: 'avg_leak', label: 'Leak', shortLabel: 'Leak', unit: 'L/min', chart: 'line', precision: 1 },
-  { key: 'large_leak_minutes', label: 'Large leak time', shortLabel: 'Large leak', unit: 'min', chart: 'bar', domain: [0, 'auto'], precision: 1 },
-  { key: 'avg_flow_lim', label: 'Flow limitation', shortLabel: 'Flow lim', unit: '', chart: 'line', precision: 3 },
-  { key: 'avg_tidal_vol', label: 'Tidal volume', shortLabel: 'Tidal vol', unit: 'mL', chart: 'line', precision: 0 },
-  { key: 'avg_min_vent', label: 'Minute ventilation', shortLabel: 'Min vent', unit: 'L/min', chart: 'line', precision: 1 },
-  { key: 'avg_resp_rate', label: 'Respiratory rate', shortLabel: 'Resp rate', unit: 'breaths/min', chart: 'line', precision: 1 },
-  { key: 'min_spo2', label: 'SpO2 minimum', shortLabel: 'Min SpO2', unit: '%', chart: 'line', domain: [70, 100], precision: 0 },
-  { key: 'avg_spo2', label: 'SpO2 average', shortLabel: 'Avg SpO2', unit: '%', chart: 'line', domain: [70, 100], precision: 1 },
-  { key: 'avg_pulse', label: 'Pulse', shortLabel: 'Pulse', unit: 'bpm', chart: 'line', precision: 0 },
-  { key: 'equipment_age_days', label: 'Equipment age', shortLabel: 'Equipment', unit: 'days', chart: 'line', domain: [0, 'auto'], precision: 0 },
+  {
+    key: 'avg_pressure',
+    label: 'Average pressure',
+    shortLabel: 'Avg pressure',
+    unit: 'cmH2O',
+    chart: 'line',
+    precision: 1,
+    guidance: {
+      range: 'There is no single good pressure number; useful pressure depends on prescription, machine mode, and airway needs.',
+      detail: 'Watch for pressure changes that line up with residual events, leak, comfort problems, or awakenings.',
+      source: 'AASM PAP guidance',
+      sourceUrl: 'https://pmc.ncbi.nlm.nih.gov/articles/PMC6374094/',
+    },
+  },
+  {
+    key: 'p95_pressure',
+    label: '95th pressure',
+    shortLabel: 'P95 pressure',
+    unit: 'cmH2O',
+    chart: 'line',
+    precision: 1,
+    guidance: {
+      range: 'There is no universal good 95th pressure; it is a context marker for where pressure spends the high end of the night.',
+      detail: 'A rising P95 can reflect more obstruction, position/REM effects, leak response, or pressure range behavior.',
+      source: 'AASM PAP guidance',
+      sourceUrl: 'https://pmc.ncbi.nlm.nih.gov/articles/PMC6374094/',
+    },
+  },
+  {
+    key: 'avg_leak',
+    label: 'Leak',
+    shortLabel: 'Leak',
+    unit: 'L/min',
+    chart: 'line',
+    precision: 1,
+    guidance: {
+      range: 'For ResMed-style unintentional leak, staying below about 24 L/min is commonly treated as acceptable.',
+      detail: 'Short leak spikes matter less than sustained large leak, especially if events rise or therapy feels worse.',
+      source: 'ResMed',
+      sourceUrl: 'https://document.resmed.com/documents/us/10114280r1_ResMed_Therapy_Handbook_AMER_Eng_Digital_SinglePages.pdf',
+    },
+  },
+  {
+    key: 'large_leak_minutes',
+    label: 'Large leak time',
+    shortLabel: 'Large leak',
+    unit: 'min',
+    chart: 'bar',
+    domain: [0, 'auto'],
+    precision: 1,
+    guidance: {
+      range: 'Less is better. SleepLab currently counts minutes above 24 L/min as large leak time.',
+      detail: 'Sustained large leak can make event detection and delivered pressure less reliable.',
+      source: 'ResMed',
+      sourceUrl: 'https://document.resmed.com/documents/us/10114280r1_ResMed_Therapy_Handbook_AMER_Eng_Digital_SinglePages.pdf',
+    },
+  },
+  {
+    key: 'avg_flow_lim',
+    label: 'Flow limitation',
+    shortLabel: 'Flow lim',
+    unit: '',
+    chart: 'line',
+    precision: 3,
+    guidance: {
+      range: 'Lower is generally better, but device-reported flow limitation does not have a universal medical cutoff.',
+      detail: 'Use it as a trend: increases can suggest partial airway restriction even when AHI remains low.',
+      source: 'SleepLab trend context',
+      sourceUrl: 'https://my.clevelandclinic.org/health/articles/apnea-hypopnea-index-ahi',
+    },
+  },
+  {
+    key: 'avg_tidal_vol',
+    label: 'Tidal volume',
+    shortLabel: 'Tidal vol',
+    unit: 'mL',
+    chart: 'line',
+    precision: 0,
+    guidance: {
+      range: 'There is no single good tidal volume in CPAP trend data.',
+      detail: 'Interpret in context with minute ventilation, respiratory rate, leak, body size, and sleep stage.',
+      source: 'SleepLab trend context',
+      sourceUrl: 'https://my.clevelandclinic.org/health/articles/10881-vital-signs',
+    },
+  },
+  {
+    key: 'avg_min_vent',
+    label: 'Minute ventilation',
+    shortLabel: 'Min vent',
+    unit: 'L/min',
+    chart: 'line',
+    precision: 1,
+    guidance: {
+      range: 'There is no universal good minute-ventilation target in home CPAP trend data.',
+      detail: 'Look for night-to-night shifts alongside respiratory rate, tidal volume, leak, and oxygen saturation.',
+      source: 'SleepLab trend context',
+      sourceUrl: 'https://my.clevelandclinic.org/health/articles/10881-vital-signs',
+    },
+  },
+  {
+    key: 'avg_resp_rate',
+    label: 'Respiratory rate',
+    shortLabel: 'Resp rate',
+    unit: 'breaths/min',
+    chart: 'line',
+    precision: 1,
+    guidance: {
+      range: 'Cleveland Clinic lists a normal adult resting respiratory rate around 12-18 breaths per minute.',
+      detail: 'Sleeping values can vary. Watch persistent shifts or changes paired with oxygen drops, leaks, or symptoms.',
+      source: 'Cleveland Clinic',
+      sourceUrl: 'https://my.clevelandclinic.org/health/articles/10881-vital-signs',
+    },
+  },
+  {
+    key: 'min_spo2',
+    label: 'SpO2 minimum',
+    shortLabel: 'Min SpO2',
+    unit: '%',
+    chart: 'line',
+    domain: [70, 100],
+    precision: 0,
+    guidance: {
+      range: 'Cleveland Clinic lists 95%-100% as normal for most pulse-oximeter readings.',
+      detail: 'A brief minimum can be artifact, but repeated or sustained drops below normal are worth reviewing with a clinician.',
+      source: 'Cleveland Clinic',
+      sourceUrl: 'https://my.clevelandclinic.org/health/diagnostics/22447-blood-oxygen-level',
+    },
+  },
+  {
+    key: 'avg_spo2',
+    label: 'SpO2 average',
+    shortLabel: 'Avg SpO2',
+    unit: '%',
+    chart: 'line',
+    domain: [70, 100],
+    precision: 1,
+    guidance: {
+      range: 'For most people, pulse-oximeter SpO2 of 95%-100% is considered normal.',
+      detail: 'Average SpO2 should be interpreted with minimum SpO2 and time spent low, not as a standalone diagnosis.',
+      source: 'Cleveland Clinic',
+      sourceUrl: 'https://my.clevelandclinic.org/health/diagnostics/22447-blood-oxygen-level',
+    },
+  },
+  {
+    key: 'avg_pulse',
+    label: 'Pulse',
+    shortLabel: 'Pulse',
+    unit: 'bpm',
+    chart: 'line',
+    precision: 0,
+    guidance: {
+      range: 'Cleveland Clinic lists normal adult resting pulse around 60-100 bpm.',
+      detail: 'Sleep pulse is often lower than daytime resting pulse. Trends are most useful beside SpO2, events, medications, and symptoms.',
+      source: 'Cleveland Clinic',
+      sourceUrl: 'https://my.clevelandclinic.org/health/articles/10881-vital-signs',
+    },
+  },
+  {
+    key: 'equipment_age_days',
+    label: 'Equipment age',
+    shortLabel: 'Equipment',
+    unit: 'days',
+    chart: 'line',
+    domain: [0, 'auto'],
+    precision: 0,
+    guidance: {
+      range: 'Replacement timing depends on the part, wear, insurance schedule, and manufacturer guidance.',
+      detail: 'Use this to spot whether leak or comfort worsens as masks, cushions, tubing, filters, or chambers age.',
+      source: 'SleepLab equipment context',
+      sourceUrl: 'https://my.clevelandclinic.org/health/articles/apnea-hypopnea-index-ahi',
+    },
+  },
 ]
 
 const TREND_METRIC_GROUPS = [
@@ -364,7 +622,24 @@ function OverviewChart({
       <CardContent className="px-4 pb-5 pt-5 sm:px-6 sm:pt-6">
         <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <p className="text-sm font-bold text-[var(--foreground)]">{metric.label}</p>
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-bold text-[var(--foreground)]">{metric.label}</p>
+              <InfoPopover title={`${metric.label} guidance`}>
+                <div className="space-y-2">
+                  <p>{metric.guidance.range}</p>
+                  <p>{metric.guidance.detail}</p>
+                  <a
+                    href={metric.guidance.sourceUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex font-bold text-[var(--accent)] hover:text-[var(--accent-hover)]"
+                  >
+                    Source: {metric.guidance.source}
+                  </a>
+                  <p className="text-xs leading-5">General education only. Use your clinician's target when it differs.</p>
+                </div>
+              </InfoPopover>
+            </div>
             <p className="text-sm text-[var(--muted-foreground)]">{nights.length} nights in the selected range</p>
           </div>
           <p className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--accent)]">{metric.unit || 'Index'}</p>


### PR DESCRIPTION
## Summary

Adds an OSCAR-style long-range Trends overview for spotting therapy patterns over time.

- adds `/stats/overview` with per-night rows for AHI/event indexes, usage, session times, pressure, leak, large leak time, flow limitation, ventilation, respiratory rate, SpO2, pulse, and equipment age
- expands the Trends page with range controls, grouped metric chips, a metric jump selector, selected-metric summary cards, charting, and a recent-night table
- renders sparse event indexes and large leak time as bars, while continuous metrics remain line charts
- adds metric guidance popovers with source links for clinical context where available
- keeps the existing AI trend card and event breakdown intact

## Validation

- `python -m py_compile api/models.py api/routers/stats.py`
- `git diff --check`
- Manual LXC visual review after Docker rebuild