### PR TITLE
fix: auto-fetch all SleepHQ history in 30-day batches with 90s delay

### DIFF
--- a/api/routers/import_settings.py
+++ b/api/routers/import_settings.py
@@ -302,14 +302,12 @@ def _run_sleephq_import_task(
     client_secret: str,
     team_id: int | None,
     machine_id: int | None,
-    lookback_days: int,
 ) -> None:
     try:
         sys.path.insert(0, str(SLEEPHQ_IMPORTER.parent))
         from sleephq_import import run_sleephq_import  # type: ignore
         run_sleephq_import(
             user_id=user_id,
-            days=lookback_days,
             client_id=client_id,
             client_secret=client_secret,
             team_id=team_id,
@@ -385,7 +383,6 @@ def trigger_sleephq_import(
         row["sleephq_client_secret"],
         row["sleephq_team_id"],
         row["sleephq_machine_id"],
-        row["lookback_days"],
     )
 
     return {"status": "started", "message": "SleepHQ import started."}

--- a/api/routers/import_settings.py
+++ b/api/routers/import_settings.py
@@ -306,6 +306,7 @@ def _run_sleephq_import_task(
     try:
         sys.path.insert(0, str(SLEEPHQ_IMPORTER.parent))
         from sleephq_import import run_sleephq_import  # type: ignore
+
         run_sleephq_import(
             user_id=user_id,
             client_id=client_id,
@@ -321,10 +322,12 @@ def _run_sleephq_import_task(
 
 def _run_local_import_task(user_id: str, datalog_path: str) -> None:
     from ..database import SessionLocal  # import here to avoid circular import at module load
+
     status: str
     try:
         sys.path.insert(0, str(LOCAL_IMPORTER.parent))
         from import_sessions import run_local_import  # type: ignore
+
         stats = run_local_import(user_id=user_id, datalog_path=datalog_path)
         status = f"ok: {stats['imported']} sessions across {stats['folders']} nights"
     except Exception:
@@ -354,10 +357,14 @@ def trigger_sleephq_import(
     current_user: dict = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    row = db.execute(
-        text("SELECT * FROM user_import_settings WHERE user_id = CAST(:uid AS uuid)"),
-        {"uid": current_user["id"]},
-    ).mappings().first()
+    row = (
+        db.execute(
+            text("SELECT * FROM user_import_settings WHERE user_id = CAST(:uid AS uuid)"),
+            {"uid": current_user["id"]},
+        )
+        .mappings()
+        .first()
+    )
 
     if os.environ.get("SLEEPHQ_ENABLED", "false").lower() != "true":
         raise HTTPException(
@@ -394,10 +401,14 @@ def trigger_local_import(
     current_user: dict = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    row = db.execute(
-        text("SELECT * FROM user_import_settings WHERE user_id = CAST(:uid AS uuid)"),
-        {"uid": current_user["id"]},
-    ).mappings().first()
+    row = (
+        db.execute(
+            text("SELECT * FROM user_import_settings WHERE user_id = CAST(:uid AS uuid)"),
+            {"uid": current_user["id"]},
+        )
+        .mappings()
+        .first()
+    )
 
     if row is None or not row.get("local_datalog_path"):
         raise HTTPException(
@@ -437,9 +448,13 @@ def trigger_all_local_imports(
     if not secret or x_import_secret != secret:
         raise HTTPException(status_code=403, detail="Invalid or missing X-Import-Secret header.")
 
-    rows = db.execute(
-        text("SELECT user_id, local_datalog_path FROM user_import_settings WHERE local_datalog_path IS NOT NULL"),
-    ).mappings().all()
+    rows = (
+        db.execute(
+            text("SELECT user_id, local_datalog_path FROM user_import_settings WHERE local_datalog_path IS NOT NULL"),
+        )
+        .mappings()
+        .all()
+    )
 
     triggered = 0
     for row in rows:
@@ -479,10 +494,14 @@ def webhook_per_user(
     if not secret or x_import_secret != secret:
         raise HTTPException(status_code=403, detail="Invalid or missing X-Import-Secret header.")
 
-    row = db.execute(
-        text("SELECT user_id, local_datalog_path FROM user_import_settings WHERE user_id = CAST(:uid AS uuid)"),
-        {"uid": str(user_id)},
-    ).mappings().first()
+    row = (
+        db.execute(
+            text("SELECT user_id, local_datalog_path FROM user_import_settings WHERE user_id = CAST(:uid AS uuid)"),
+            {"uid": str(user_id)},
+        )
+        .mappings()
+        .first()
+    )
 
     if row is None:
         raise HTTPException(status_code=404, detail="User not found or no import settings configured.")

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -55,6 +55,7 @@ export default function SettingsPage() {
   const [sleephqSecretDirty, setSleephqSecretDirty] = useState(false)
   const [sleephqTeamId, setSleephqTeamId] = useState('')
   const [sleephqMachineId, setSleephqMachineId] = useState('')
+  const [sleephqLookbackDays, setSleephqLookbackDays] = useState(30)
   const [sleephqMessage, setSleephqMessage] = useState<string | null>(null)
   const [sleephqError, setSleephqError] = useState<string | null>(null)
   const [isSleephqSubmitting, setIsSleephqSubmitting] = useState(false)
@@ -115,6 +116,7 @@ export default function SettingsPage() {
       setSleephqSecretSaved(settings.has_client_secret)
       setSleephqTeamId(settings.sleephq_team_id != null ? String(settings.sleephq_team_id) : '')
       setSleephqMachineId(settings.sleephq_machine_id != null ? String(settings.sleephq_machine_id) : '')
+      setSleephqLookbackDays(settings.lookback_days ?? 30)
       setLocalPath(settings.local_datalog_path ?? '')
       setLocalFrequency(settings.local_import_frequency ?? 'daily')
       setLastImportAt(settings.last_local_import_at)
@@ -306,6 +308,7 @@ export default function SettingsPage() {
         sleephq_client_secret: sleephqSecretDirty ? (sleephqClientSecret || null) : null,
         sleephq_team_id: sleephqTeamId ? Number(sleephqTeamId) : null,
         sleephq_machine_id: sleephqMachineId ? Number(sleephqMachineId) : null,
+        lookback_days: sleephqLookbackDays,
       })
       setSleephqMessage('SleepHQ settings saved.')
       if (sleephqSecretDirty && sleephqClientSecret) {
@@ -468,7 +471,7 @@ export default function SettingsPage() {
               )}
             </div>
 
-            <div className="grid gap-4 sm:grid-cols-2">
+            <div className="grid gap-4 sm:grid-cols-3">
               <div className="space-y-3">
                 <Label htmlFor="sleephqTeamId">Team ID</Label>
                 <Input
@@ -487,6 +490,17 @@ export default function SettingsPage() {
                   onChange={(event) => setSleephqMachineId(event.target.value)}
                   inputMode="numeric"
                   placeholder="Optional — auto-resolved if blank"
+                />
+              </div>
+              <div className="space-y-3">
+                <Label htmlFor="sleephqLookbackDays">Lookback days</Label>
+                <Input
+                  id="sleephqLookbackDays"
+                  type="number"
+                  value={sleephqLookbackDays}
+                  onChange={(event) => setSleephqLookbackDays(Number(event.target.value))}
+                  min={1}
+                  placeholder="30"
                 />
               </div>
             </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -429,7 +429,7 @@ export default function SettingsPage() {
         <CardHeader>
           <CardTitle className="text-2xl">SleepHQ API Import (Unofficial)</CardTitle>
           <CardDescription>
-            Import your CPAP history from SleepHQ. This is a one-time historical import — it pulls your existing records into SleepLab and does not stay connected or sync automatically. You can re-run it at any time to pull in newer sessions. OAuth credentials can be found in your SleepHQ developer settings.
+            Import your CPAP history from SleepHQ. This is a one-time historical import — it pulls your existing records into SleepLab and does not stay connected or sync automatically. You can re-run it at any time to pull in newer sessions. OAuth credentials can be found in your SleepHQ developer settings. Only read scope is requested — no data is written or deleted on SleepHQ.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -55,7 +55,6 @@ export default function SettingsPage() {
   const [sleephqSecretDirty, setSleephqSecretDirty] = useState(false)
   const [sleephqTeamId, setSleephqTeamId] = useState('')
   const [sleephqMachineId, setSleephqMachineId] = useState('')
-  const [sleephqLookbackDays, setSleephqLookbackDays] = useState(30)
   const [sleephqMessage, setSleephqMessage] = useState<string | null>(null)
   const [sleephqError, setSleephqError] = useState<string | null>(null)
   const [isSleephqSubmitting, setIsSleephqSubmitting] = useState(false)
@@ -116,7 +115,6 @@ export default function SettingsPage() {
       setSleephqSecretSaved(settings.has_client_secret)
       setSleephqTeamId(settings.sleephq_team_id != null ? String(settings.sleephq_team_id) : '')
       setSleephqMachineId(settings.sleephq_machine_id != null ? String(settings.sleephq_machine_id) : '')
-      setSleephqLookbackDays(settings.lookback_days ?? 30)
       setLocalPath(settings.local_datalog_path ?? '')
       setLocalFrequency(settings.local_import_frequency ?? 'daily')
       setLastImportAt(settings.last_local_import_at)
@@ -308,7 +306,6 @@ export default function SettingsPage() {
         sleephq_client_secret: sleephqSecretDirty ? (sleephqClientSecret || null) : null,
         sleephq_team_id: sleephqTeamId ? Number(sleephqTeamId) : null,
         sleephq_machine_id: sleephqMachineId ? Number(sleephqMachineId) : null,
-        lookback_days: sleephqLookbackDays,
       })
       setSleephqMessage('SleepHQ settings saved.')
       if (sleephqSecretDirty && sleephqClientSecret) {
@@ -471,7 +468,7 @@ export default function SettingsPage() {
               )}
             </div>
 
-            <div className="grid gap-4 sm:grid-cols-3">
+            <div className="grid gap-4 sm:grid-cols-2">
               <div className="space-y-3">
                 <Label htmlFor="sleephqTeamId">Team ID</Label>
                 <Input
@@ -490,17 +487,6 @@ export default function SettingsPage() {
                   onChange={(event) => setSleephqMachineId(event.target.value)}
                   inputMode="numeric"
                   placeholder="Optional — auto-resolved if blank"
-                />
-              </div>
-              <div className="space-y-3">
-                <Label htmlFor="sleephqLookbackDays">Lookback days</Label>
-                <Input
-                  id="sleephqLookbackDays"
-                  type="number"
-                  value={sleephqLookbackDays}
-                  onChange={(event) => setSleephqLookbackDays(Number(event.target.value))}
-                  min={1}
-                  placeholder="30"
                 />
               </div>
             </div>

--- a/importer/sleephq_import.py
+++ b/importer/sleephq_import.py
@@ -73,6 +73,12 @@ _MAX_DELAY = 300.0  # 5 minutes
 #: Polite pause between successive paginated API requests.
 _PAGE_DELAY = 1.5  # seconds
 
+#: Number of days per batch when walking the full history.
+_BATCH_WINDOW = 30
+
+#: Delay in seconds between history batches to avoid rate limiting.
+_BATCH_DELAY = 90.0
+
 
 def _backoff_delay(attempt: int, retry_after_header: str | None = None) -> float:
     """
@@ -325,6 +331,49 @@ def fetch_machine_dates(
             break
 
         page += 1
+
+    return all_records
+
+
+def fetch_all_machine_dates(
+    client: AuthenticatedClient,
+    machine_id: int,
+) -> list:
+    """
+    Fetch every available machine_dates record by walking backwards in
+    30-day windows with a 90-second pause between each batch.
+
+    This avoids hammering the SleepHQ API with one giant paginated
+    request when importing years of history.
+    """
+    all_records: list = []
+    to_date = date.today()
+
+    while True:
+        from_date = to_date - timedelta(days=_BATCH_WINDOW)
+
+        batch = fetch_machine_dates(
+            client,
+            machine_id=machine_id,
+            from_date=from_date,
+            to_date=to_date,
+        )
+
+        if not batch:
+            break
+
+        all_records.extend(batch)
+        print(
+            f"  Batch complete: {len(batch)} records, "
+            f"{len(all_records)} total so far"
+        )
+
+        to_date = from_date - timedelta(days=1)
+        if to_date < date(2000, 1, 1):
+            break
+
+        print(f"  Waiting {_BATCH_DELAY}s before next batch…")
+        time.sleep(_BATCH_DELAY)
 
     return all_records
 
@@ -661,13 +710,19 @@ def run_sleephq_import(
             f"machine={resolved_machine_id} user={user_id}"
         )
 
-        records = fetch_machine_dates(
-            client,
-            machine_id=resolved_machine_id,
-            from_date=from_date,
-            to_date=to_date,
-            days=days,
-        )
+        if from_date or to_date:
+            records = fetch_machine_dates(
+                client,
+                machine_id=resolved_machine_id,
+                from_date=from_date,
+                to_date=to_date,
+                days=days,
+            )
+        else:
+            records = fetch_all_machine_dates(
+                client,
+                machine_id=resolved_machine_id,
+            )
         print(f"  Fetched {len(records)} record(s) from SleepHQ")
 
         if not records:

--- a/importer/sleephq_import.py
+++ b/importer/sleephq_import.py
@@ -48,6 +48,7 @@ try:
     from sleephq.api.machines import get_v1_teams_team_id_machines
     from sleephq.api.teams import get_v1_teams
     from sleephq.auth import create_client as _sleephq_create_client
+
     _SLEEPHQ_AVAILABLE = True
 except ImportError:
     _SLEEPHQ_AVAILABLE = False
@@ -92,7 +93,7 @@ def _backoff_delay(attempt: int, retry_after_header: str | None = None) -> float
             return max(1.0, float(retry_after_header))
         except (TypeError, ValueError):
             pass
-    cap = min(_BASE_DELAY * (2 ** attempt), _MAX_DELAY)
+    cap = min(_BASE_DELAY * (2**attempt), _MAX_DELAY)
     return random.uniform(0, cap)
 
 
@@ -132,11 +133,11 @@ def _api_call_with_retry(fn, *args, label: str = "API call", **kwargs):
 # Client / authentication
 # ---------------------------------------------------------------------------
 
+
 def _require_sleephq():
     if not _SLEEPHQ_AVAILABLE:
         raise RuntimeError(
-            "sleephq-client is not installed. "
-            "Set SLEEPHQ_ENABLED=true in your environment to enable SleepHQ support."
+            "sleephq-client is not installed. Set SLEEPHQ_ENABLED=true in your environment to enable SleepHQ support."
         )
 
 
@@ -171,14 +172,13 @@ def create_sleephq_client(
             time.sleep(wait)
             last_exc = exc
 
-    raise RuntimeError(
-        f"SleepHQ authentication failed after {_MAX_ATTEMPTS} attempts"
-    ) from last_exc
+    raise RuntimeError(f"SleepHQ authentication failed after {_MAX_ATTEMPTS} attempts") from last_exc
 
 
 # ---------------------------------------------------------------------------
 # ID resolution helpers
 # ---------------------------------------------------------------------------
+
 
 def resolve_team_id(client: AuthenticatedClient) -> int:
     """Return the team ID from env or auto-resolve via the API."""
@@ -186,9 +186,7 @@ def resolve_team_id(client: AuthenticatedClient) -> int:
     if env_val:
         return int(env_val)
 
-    resp = _api_call_with_retry(
-        get_v1_teams.sync_detailed, client=client, label="GET /teams"
-    )
+    resp = _api_call_with_retry(get_v1_teams.sync_detailed, client=client, label="GET /teams")
     if resp.status_code != 200 or not resp.parsed:
         raise RuntimeError(f"Failed to list teams: HTTP {resp.status_code}")
 
@@ -225,6 +223,7 @@ def resolve_machine_id(client: AuthenticatedClient, team_id: int) -> int:
 # Data fetching
 # ---------------------------------------------------------------------------
 
+
 def fetch_machine_dates(
     client: AuthenticatedClient,
     machine_id: int,
@@ -256,10 +255,7 @@ def fetch_machine_dates(
     to_date = to_date or date.today()
 
     span_days = (to_date - from_date).days
-    print(
-        f"  Fetching machine_dates for machine {machine_id}: "
-        f"{from_date} → {to_date} ({span_days} days)"
-    )
+    print(f"  Fetching machine_dates for machine {machine_id}: {from_date} → {to_date} ({span_days} days)")
 
     all_records: list = []
     page = 1
@@ -277,9 +273,7 @@ def fetch_machine_dates(
         )
 
         if resp.status_code != 200:
-            raise RuntimeError(
-                f"machine_dates fetch failed on page {page}: HTTP {resp.status_code}"
-            )
+            raise RuntimeError(f"machine_dates fetch failed on page {page}: HTTP {resp.status_code}")
 
         parsed = resp.parsed
         if parsed is None:
@@ -294,7 +288,7 @@ def fetch_machine_dates(
 
         for rec in records:
             rec_attrs = getattr(rec, "attributes", None)
-            rec_date  = getattr(rec_attrs, "date", None) if rec_attrs else None
+            rec_date = getattr(rec_attrs, "date", None) if rec_attrs else None
             if isinstance(rec_date, Unset):
                 rec_date = None
 
@@ -323,8 +317,7 @@ def fetch_machine_dates(
             page_kept += 1
 
         print(
-            f"    page {page}: {len(records)} records returned, "
-            f"{page_kept} in window, {len(all_records)} total so far"
+            f"    page {page}: {len(records)} records returned, {page_kept} in window, {len(all_records)} total so far"
         )
 
         if reached_start or len(records) < 100:
@@ -363,10 +356,7 @@ def fetch_all_machine_dates(
             break
 
         all_records.extend(batch)
-        print(
-            f"  Batch complete: {len(batch)} records, "
-            f"{len(all_records)} total so far"
-        )
+        print(f"  Batch complete: {len(batch)} records, {len(all_records)} total so far")
 
         to_date = from_date - timedelta(days=1)
         if to_date < date(2000, 1, 1):
@@ -381,6 +371,7 @@ def fetch_all_machine_dates(
 # ---------------------------------------------------------------------------
 # Field mapping
 # ---------------------------------------------------------------------------
+
 
 def _attr(obj, *names, default=None):
     """Return the first attribute in `names` that exists and is not None."""
@@ -411,6 +402,7 @@ def _sub(summary_obj, *keys, default=None):
     if summary_obj is None:
         return default
     from sleephq.types import Unset
+
     if isinstance(summary_obj, Unset):
         return default
     props = getattr(summary_obj, "additional_properties", {}) or {}
@@ -453,11 +445,7 @@ def map_machine_date_to_session(record, user_id: str) -> dict:
     # ── Start datetime ───────────────────────────────────────────────────────
     # SleepHQ doesn't expose a start_time on machine_dates; use midnight of
     # the session date as a reasonable default.
-    start_datetime = (
-        datetime(folder_date.year, folder_date.month, folder_date.day)
-        if folder_date
-        else None
-    )
+    start_datetime = datetime(folder_date.year, folder_date.month, folder_date.day) if folder_date else None
 
     # ── Duration ─────────────────────────────────────────────────────────────
     # attributes.usage is confirmed to be in seconds (e.g. 27960 = ~7.8 h).
@@ -500,9 +488,9 @@ def map_machine_date_to_session(record, user_id: str) -> dict:
 
     ca = _index_to_count(_sub(ahi_s, "clear_airway"))
     oa = _index_to_count(_sub(ahi_s, "obstructive_apnea"))
-    h  = _index_to_count(_sub(ahi_s, "hypopnea"))
+    h = _index_to_count(_sub(ahi_s, "hypopnea"))
     # all_apnea covers obstructive + unidentified; store as the generic apnea count
-    a  = _index_to_count(_sub(ahi_s, "all_apnea"))
+    a = _index_to_count(_sub(ahi_s, "all_apnea"))
     ar = None  # not present in machine_dates
 
     total_ahi_events = _index_to_count(_sub(ahi_s, "total"))
@@ -535,15 +523,13 @@ def map_machine_date_to_session(record, user_id: str) -> dict:
     # Returns empty dict for most machines; has_spo2 = True only if non-empty
     spo2_s = getattr(attrs, "spo2_summary", None) if attrs else None
     has_spo2 = bool(
-        spo2_s is not None
-        and not isinstance(spo2_s, Unset)
-        and getattr(spo2_s, "additional_properties", {})
+        spo2_s is not None and not isinstance(spo2_s, Unset) and getattr(spo2_s, "additional_properties", {})
     )
 
     # Fields not present in machine_dates (no per-session waveform summaries)
     avg_tidal_vol = None
-    avg_min_vent  = None
-    avg_snore     = None
+    avg_min_vent = None
+    avg_snore = None
 
     # ── Device serial ────────────────────────────────────────────────────────
     # Not present on machine_dates; would need to join against the machine record
@@ -554,8 +540,8 @@ def map_machine_date_to_session(record, user_id: str) -> dict:
     ms = getattr(attrs, "machine_settings", None) if attrs else None
     ms_props = getattr(ms, "additional_properties", {}) or {} if ms and not isinstance(ms, Unset) else {}
 
-    therapy_mode   = ms_props.get("mode") or None
-    mask_type      = ms_props.get("mask") or None
+    therapy_mode = ms_props.get("mode") or None
+    mask_type = ms_props.get("mask") or None
     humidity_level = _int(ms_props.get("humidity_level"))
 
     temperature_c = None
@@ -568,41 +554,42 @@ def map_machine_date_to_session(record, user_id: str) -> dict:
             pass
 
     return {
-        "session_id":              session_id,
-        "folder_date":             folder_date,
-        "block_index":             0,
-        "start_datetime":          start_datetime,
-        "pld_start_datetime":      start_datetime,
-        "duration_seconds":        duration_seconds,
-        "device_serial":           device_serial,
-        "ahi":                     ahi,
-        "central_apnea_count":     ca,
+        "session_id": session_id,
+        "folder_date": folder_date,
+        "block_index": 0,
+        "start_datetime": start_datetime,
+        "pld_start_datetime": start_datetime,
+        "duration_seconds": duration_seconds,
+        "device_serial": device_serial,
+        "ahi": ahi,
+        "central_apnea_count": ca,
         "obstructive_apnea_count": oa,
-        "hypopnea_count":          h,
-        "apnea_count":             a,
-        "arousal_count":           ar,
-        "total_ahi_events":        total_ahi_events,
-        "avg_pressure":            avg_pressure,
-        "p95_pressure":            p95_pressure,
-        "avg_leak":                avg_leak,
-        "avg_resp_rate":           avg_resp_rate,
-        "avg_tidal_vol":           avg_tidal_vol,
-        "avg_min_vent":            avg_min_vent,
-        "avg_snore":               avg_snore,
-        "avg_flow_lim":            avg_flow_lim,
-        "has_spo2":                has_spo2,
-        "therapy_mode":            therapy_mode,
-        "mask_type":               mask_type,
-        "humidity_level":          humidity_level,
-        "temperature_c":           temperature_c,
-        "machine_tz":              "UTC",
-        "user_id":                 user_id,
+        "hypopnea_count": h,
+        "apnea_count": a,
+        "arousal_count": ar,
+        "total_ahi_events": total_ahi_events,
+        "avg_pressure": avg_pressure,
+        "p95_pressure": p95_pressure,
+        "avg_leak": avg_leak,
+        "avg_resp_rate": avg_resp_rate,
+        "avg_tidal_vol": avg_tidal_vol,
+        "avg_min_vent": avg_min_vent,
+        "avg_snore": avg_snore,
+        "avg_flow_lim": avg_flow_lim,
+        "has_spo2": has_spo2,
+        "therapy_mode": therapy_mode,
+        "mask_type": mask_type,
+        "humidity_level": humidity_level,
+        "temperature_c": temperature_c,
+        "machine_tz": "UTC",
+        "user_id": user_id,
     }
 
 
 # ---------------------------------------------------------------------------
 # Persistence
 # ---------------------------------------------------------------------------
+
 
 def persist_sessions(
     conn,
@@ -662,6 +649,7 @@ def persist_sessions(
 # Main pipeline
 # ---------------------------------------------------------------------------
 
+
 def run_sleephq_import(
     user_id: str,
     days: int = 30,
@@ -705,10 +693,7 @@ def run_sleephq_import(
         resolved_team_id = resolve_team_id(client)
         resolved_machine_id = resolve_machine_id(client, resolved_team_id)
 
-        print(
-            f"SleepHQ import: team={resolved_team_id} "
-            f"machine={resolved_machine_id} user={user_id}"
-        )
+        print(f"SleepHQ import: team={resolved_team_id} machine={resolved_machine_id} user={user_id}")
 
         if from_date or to_date:
             records = fetch_machine_dates(
@@ -759,37 +744,20 @@ def run_sleephq_import(
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def _parse_args():
-    parser = argparse.ArgumentParser(
-        description="Import SleepHQ session history into the sleeplab database"
-    )
-    parser.add_argument(
-        "--user-id", required=True, dest="user_id",
-        help="User UUID to associate sessions with"
-    )
+    parser = argparse.ArgumentParser(description="Import SleepHQ session history into the sleeplab database")
+    parser.add_argument("--user-id", required=True, dest="user_id", help="User UUID to associate sessions with")
 
     date_group = parser.add_mutually_exclusive_group()
-    date_group.add_argument(
-        "--days", type=int, default=30,
-        help="Number of past days to fetch (default: 30)"
-    )
-    date_group.add_argument(
-        "--from", dest="from_date", metavar="YYYY-MM-DD",
-        help="Start of date range (inclusive)"
-    )
+    date_group.add_argument("--days", type=int, default=30, help="Number of past days to fetch (default: 30)")
+    date_group.add_argument("--from", dest="from_date", metavar="YYYY-MM-DD", help="Start of date range (inclusive)")
 
     parser.add_argument(
-        "--to", dest="to_date", metavar="YYYY-MM-DD",
-        help="End of date range (inclusive, default: today)"
+        "--to", dest="to_date", metavar="YYYY-MM-DD", help="End of date range (inclusive, default: today)"
     )
-    parser.add_argument(
-        "--dry-run", action="store_true",
-        help="Fetch and map records but do not write to the database"
-    )
-    parser.add_argument(
-        "--force", action="store_true",
-        help="Overwrite existing sessions instead of skipping them"
-    )
+    parser.add_argument("--dry-run", action="store_true", help="Fetch and map records but do not write to the database")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing sessions instead of skipping them")
     return parser.parse_args()
 
 
@@ -797,7 +765,7 @@ def main():
     args = _parse_args()
 
     from_date = date.fromisoformat(args.from_date) if args.from_date else None
-    to_date   = date.fromisoformat(args.to_date)   if args.to_date   else None
+    to_date = date.fromisoformat(args.to_date) if args.to_date else None
 
     run_sleephq_import(
         user_id=args.user_id,

--- a/importer/sleephq_import.py
+++ b/importer/sleephq_import.py
@@ -39,22 +39,20 @@ import random
 import sys
 import time
 from datetime import date, datetime, timedelta
-from typing import Optional
 
 import httpx
 
 try:
     from sleephq import AuthenticatedClient
-    from sleephq.auth import create_client as _sleephq_create_client
     from sleephq.api.machine_dates import get_v1_machines_machine_id_machine_dates
-    from sleephq.api.teams import get_v1_teams
     from sleephq.api.machines import get_v1_teams_team_id_machines
+    from sleephq.api.teams import get_v1_teams
+    from sleephq.auth import create_client as _sleephq_create_client
     _SLEEPHQ_AVAILABLE = True
 except ImportError:
     _SLEEPHQ_AVAILABLE = False
 
 from db import get_conn, session_exists, upsert_session
-
 
 # ---------------------------------------------------------------------------
 # Rate-limit / retry helpers
@@ -76,7 +74,7 @@ _MAX_DELAY = 300.0  # 5 minutes
 _PAGE_DELAY = 1.5  # seconds
 
 
-def _backoff_delay(attempt: int, retry_after_header: Optional[str] = None) -> float:
+def _backoff_delay(attempt: int, retry_after_header: str | None = None) -> float:
     """
     Return how many seconds to wait before the next attempt.
 
@@ -137,8 +135,8 @@ def _require_sleephq():
 
 
 def create_sleephq_client(
-    client_id: Optional[str] = None,
-    client_secret: Optional[str] = None,
+    client_id: str | None = None,
+    client_secret: str | None = None,
 ) -> AuthenticatedClient:
     """
     Authenticate with SleepHQ via OAuth2 and return an authenticated client.
@@ -150,10 +148,10 @@ def create_sleephq_client(
     cid = client_id or os.environ["SLEEPHQ_CLIENT_ID"]
     csecret = client_secret or os.environ["SLEEPHQ_CLIENT_SECRET"]
 
-    last_exc: Optional[Exception] = None
+    last_exc: Exception | None = None
     for attempt in range(_MAX_ATTEMPTS):
         try:
-            return _sleephq_create_client(client_id=cid, client_secret=csecret)
+            return _sleephq_create_client(client_id=cid, client_secret=csecret, scope="read")
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code not in _RETRY_STATUSES:
                 raise
@@ -224,8 +222,8 @@ def resolve_machine_id(client: AuthenticatedClient, team_id: int) -> int:
 def fetch_machine_dates(
     client: AuthenticatedClient,
     machine_id: int,
-    from_date: Optional[date] = None,
-    to_date: Optional[date] = None,
+    from_date: date | None = None,
+    to_date: date | None = None,
     days: int = 30,
 ) -> list:
     """
@@ -618,14 +616,14 @@ def persist_sessions(
 def run_sleephq_import(
     user_id: str,
     days: int = 30,
-    from_date: Optional[date] = None,
-    to_date: Optional[date] = None,
+    from_date: date | None = None,
+    to_date: date | None = None,
     skip_existing: bool = True,
     dry_run: bool = False,
-    client_id: Optional[str] = None,
-    client_secret: Optional[str] = None,
-    team_id: Optional[int] = None,
-    machine_id: Optional[int] = None,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    team_id: int | None = None,
+    machine_id: int | None = None,
 ) -> dict:
     """
     Full SleepHQ → Postgres pipeline.


### PR DESCRIPTION
## Summary
- Walk backwards through full SleepHQ history in 30-day windows with 90s inter-batch delay
- Pass explicit \`scope="read"\` to OAuth client (was defaulting to read/write/delete)
- Remove manual \`lookback_days\` config — auto-discovery replaces it

## Dependency fix
This branch was cut before #43 landed, so it re-introduced \`python-jose==3.5.0\` and
\`ecdsa>=0.19.3\` — sorry for the noise. The PyJWT migration from #43 has been
cherry-picked onto this branch to remove both. \`ecdsa\` is now gone.

## Test Plan
- [ ] \`uv run ruff check .\` passes
- [ ] \`uv run pytest -v --tb=short\` passes (DB tests skip without Postgres)
- [ ] Trigger SleepHQ sync and verify it fetches sessions beyond 30 days
- [ ] Verify OAuth flow only requests read scope
- [ ] Confirm \`lookback_days\` field no longer appears in Settings UI