### PR TITLE
fix(docs): correct sleephq env examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,8 +47,10 @@ OPENAI_API_KEY=
 # Set to "true" to enable SleepHQ cloud import.
 SLEEPHQ_ENABLED=false
 # Required when SLEEPHQ_ENABLED=true:
-# SLEEPHQ_API_KEY=
-# SLEEPHQ_BASE_URL=
+# SLEEPHQ_CLIENT_ID=
+# SLEEPHQ_CLIENT_SECRET=
+# Optional; auto-resolved if omitted:
+# SLEEPHQ_TEAM_ID=
 
 # Shared secret for CPAP import webhooks.  Generate with: openssl rand -hex 16
 IMPORT_WEBHOOK_SECRET=

--- a/compose.advanced.yaml
+++ b/compose.advanced.yaml
@@ -79,7 +79,8 @@ services:
 
       # --- Optional: SleepHQ cloud import ------------------------------------
       # Set to "true" and the sleephq-client package will be installed at startup.
-      # Requires SLEEPHQ_API_KEY and SLEEPHQ_BASE_URL in your .env.
+      # Requires SLEEPHQ_CLIENT_ID and SLEEPHQ_CLIENT_SECRET in your .env.
+      # SLEEPHQ_TEAM_ID is optional and auto-resolved if omitted.
       SLEEPHQ_ENABLED: ${SLEEPHQ_ENABLED:-false}
 
       # --- Optional: Import webhook ------------------------------------------


### PR DESCRIPTION
## Summary

- Correct the SleepHQ variables documented in `compose.advanced.yaml`
- Update `.env.example` to use the OAuth credential names the importer actually reads
- Keep the optional team ID guidance aligned with the README

Fixes #97

## Validation

- `rg "SLEEPHQ_API_KEY|SLEEPHQ_BASE_URL" compose.advanced.yaml .env.example README.md importer api docker frontend` - no matches
- `rg "SLEEPHQ_CLIENT_ID|SLEEPHQ_CLIENT_SECRET|SLEEPHQ_TEAM_ID" compose.advanced.yaml .env.example README.md importer/sleephq_import.py` - confirmed consistent references
- `.venv/bin/ruff check tests/` - passed
- `.venv/bin/python -m pytest -v --tb=short` - 36 passed, 67 skipped, 1 warning
- `npx tsc --noEmit -p tsconfig.app.json` in `frontend/` - passed
- `npx vitest run` in `frontend/` - 2 files passed, 4 tests passed
