### PR TITLE
fix: surface failed import job status

### DIFF
--- a/api/routers/upload.py
+++ b/api/routers/upload.py
@@ -1,3 +1,4 @@
+import logging
 import shutil
 import subprocess
 import sys
@@ -19,6 +20,7 @@ from ..oximeter import OximeterParseError, OximeterRecording, parse_viatom_binar
 from ..settings_store import get_timezone_settings, normalize_timezone
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 IMPORTER_SCRIPT = Path(__file__).resolve().parent.parent.parent / "importer" / "import_sessions.py"
 
@@ -50,6 +52,8 @@ class OximeterImportResult(BaseModel):
 
 
 class OximeterImportResponse(BaseModel):
+    status: Literal["completed", "partial", "failed"]
+    message: str
     imported: int
     skipped: int
     unmatched: int
@@ -61,6 +65,8 @@ class OximeterImportResponse(BaseModel):
 class ImportJobStatus:
     running: bool
     started_at: str | None = None
+    status: Literal["running", "completed", "failed"] = "completed"
+    message: str | None = None
 
 
 IMPORT_JOBS: dict[str, ImportJobStatus] = {}
@@ -70,11 +76,22 @@ def _mark_import_running(user_id: str) -> None:
     IMPORT_JOBS[user_id] = ImportJobStatus(
         running=True,
         started_at=datetime.now(UTC).isoformat(),
+        status="running",
+        message="Import is running.",
     )
 
 
-def _mark_import_finished(user_id: str) -> None:
-    IMPORT_JOBS[user_id] = ImportJobStatus(running=False, started_at=None)
+def _mark_import_finished(
+    user_id: str,
+    status: Literal["completed", "failed"] = "completed",
+    message: str | None = None,
+) -> None:
+    IMPORT_JOBS[user_id] = ImportJobStatus(
+        running=False,
+        started_at=None,
+        status=status,
+        message=message,
+    )
 
 
 def _run_import(datalog_path: str, user_id: str, from_date: str | None, cleanup_dir: str | None = None) -> None:
@@ -91,9 +108,16 @@ def _run_import(datalog_path: str, user_id: str, from_date: str | None, cleanup_
         cmd.extend(["--from", from_date])
 
     try:
-        subprocess.run(cmd, cwd=str(IMPORTER_SCRIPT.parent), check=False)
+        result = subprocess.run(cmd, cwd=str(IMPORTER_SCRIPT.parent), check=False)
+        if result.returncode == 0:
+            _mark_import_finished(user_id, "completed", "Import completed.")
+        else:
+            logger.error("DATALOG import failed for user %s with exit code %s", user_id, result.returncode)
+            _mark_import_finished(user_id, "failed", "Import failed. Check the uploaded files and try again.")
+    except Exception:
+        logger.exception("DATALOG import failed for user %s", user_id)
+        _mark_import_finished(user_id, "failed", "Import failed. Check the uploaded files and try again.")
     finally:
-        _mark_import_finished(user_id)
         if cleanup_dir:
             shutil.rmtree(cleanup_dir, ignore_errors=True)
 
@@ -209,10 +233,12 @@ def _require_session(upload_id: str, user_id: str) -> UploadSession:
 def get_upload_status(current_user: dict = Depends(get_current_user)):
     job = IMPORT_JOBS.get(current_user["id"])
     if job is None:
-        return {"running": False, "started_at": None}
+        return {"running": False, "started_at": None, "status": "completed", "message": None}
     return {
         "running": job.running,
         "started_at": job.started_at,
+        "status": job.status,
+        "message": job.message,
     }
 
 
@@ -245,15 +271,40 @@ async def upload_oximeter_files(
             results.append(_import_oximeter_recording(db, current_user["id"], filename, recording, overwrite))
         except OximeterParseError as exc:
             results.append(OximeterImportResult(filename=filename, status="failed", message=str(exc)))
+        except Exception:
+            logger.exception("Oximeter import failed for user %s file %s", current_user["id"], filename)
+            results.append(
+                OximeterImportResult(
+                    filename=filename,
+                    status="failed",
+                    message="Could not import this oximeter file. Check the file and try again.",
+                ),
+            )
         finally:
             await upload.close()
 
     db.commit()
+    imported = sum(1 for result in results if result.status == "imported")
+    skipped = sum(1 for result in results if result.status == "skipped")
+    unmatched = sum(1 for result in results if result.status == "unmatched")
+    failed = sum(1 for result in results if result.status == "failed")
+    status: Literal["completed", "partial", "failed"]
+    if failed and imported + skipped + unmatched == 0:
+        status = "failed"
+        message = "No oximeter files could be imported."
+    elif failed:
+        status = "partial"
+        message = "Some oximeter files could not be imported."
+    else:
+        status = "completed"
+        message = "Oximeter import completed."
     return OximeterImportResponse(
-        imported=sum(1 for result in results if result.status == "imported"),
-        skipped=sum(1 for result in results if result.status == "skipped"),
-        unmatched=sum(1 for result in results if result.status == "unmatched"),
-        failed=sum(1 for result in results if result.status == "failed"),
+        status=status,
+        message=message,
+        imported=imported,
+        skipped=skipped,
+        unmatched=unmatched,
+        failed=failed,
         results=results,
     )
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -84,6 +84,7 @@ function AppLayout() {
   const [latestVersion, setLatestVersion] = useState<string | null>(null)
   const [releaseUrl, setReleaseUrl] = useState<string | null>(null)
   const [isSyncing, setIsSyncing] = useState(false)
+  const [importError, setImportError] = useState<string | null>(null)
   const userMenuRef = useRef<HTMLDivElement | null>(null)
   const wasSyncingRef = useRef(false)
 
@@ -154,6 +155,7 @@ function AppLayout() {
   useEffect(() => {
     if (!user || isLoading) {
       setIsSyncing(false)
+      setImportError(null)
       wasSyncingRef.current = false
       window.sessionStorage.removeItem(IMPORT_SYNC_STORAGE_KEY)
       return
@@ -175,10 +177,16 @@ function AppLayout() {
         const hadBeenSyncing = wasSyncingRef.current
         setIsSyncing(status.running)
         if (status.running) {
+          setImportError(null)
           wasSyncingRef.current = true
           window.sessionStorage.setItem(IMPORT_SYNC_STORAGE_KEY, 'true')
         } else {
-          if (hadBeenSyncing && user) {
+          if (status.status === 'failed' && (hadBeenSyncing || hasPendingSync)) {
+            setImportError(status.message || 'Import failed. Check the uploaded files and try again.')
+          } else {
+            setImportError(null)
+          }
+          if (hadBeenSyncing && user && status.status === 'completed') {
             notifyImportCompleted()
           }
           wasSyncingRef.current = false
@@ -404,6 +412,14 @@ function AppLayout() {
                   <p className="text-sm font-medium text-[var(--accent)]/80">
                     We are importing your sleep data, so visualisations may be out of date.
                   </p>
+                </div>
+              </div>
+            ) : null}
+            {user && !isLoading && importError ? (
+              <div className="flex items-start gap-3 rounded-[18px] border border-[rgba(176,58,46,0.28)] bg-[rgba(176,58,46,0.08)] px-4 py-3 text-[var(--danger-text)]">
+                <div className="space-y-1">
+                  <p className="text-sm font-bold">Import failed</p>
+                  <p className="text-sm font-medium">{importError}</p>
                 </div>
               </div>
             ) : null}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -60,6 +60,8 @@ export interface StartImportResponse {
 export interface ImportStatusResponse {
   running: boolean
   started_at: string | null
+  status: 'running' | 'completed' | 'failed'
+  message: string | null
 }
 
 export interface OximeterImportResult {
@@ -72,6 +74,8 @@ export interface OximeterImportResult {
 }
 
 export interface OximeterImportResponse {
+  status: 'completed' | 'partial' | 'failed'
+  message: string
   imported: number
   skipped: number
   unmatched: number

--- a/frontend/src/pages/Import.test.tsx
+++ b/frontend/src/pages/Import.test.tsx
@@ -34,6 +34,8 @@ describe('OximeterImportSummary', () => {
     render(
       <OximeterImportSummary
         result={{
+          status: 'partial',
+          message: 'Some oximeter files could not be imported.',
           imported: 1,
           skipped: 1,
           unmatched: 1,
@@ -49,6 +51,7 @@ describe('OximeterImportSummary', () => {
     )
 
     expect(screen.getByText('imported.bin')).toBeInTheDocument()
+    expect(screen.getByText('Some oximeter files could not be imported.')).toBeInTheDocument()
     expect(screen.getByText('skipped.bin')).toBeInTheDocument()
     expect(screen.getByText('unmatched.bin')).toBeInTheDocument()
     expect(screen.getByText('failed.bin')).toBeInTheDocument()

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -266,12 +266,11 @@ export default function Import() {
               </div>
             ) : null}
             {uploadPhase === 'complete' ? (
-              <div className="flex items-start gap-3 rounded-[20px] border border-[rgba(106,161,54,0.24)] bg-[rgba(106,161,54,0.1)] p-4 text-[var(--olive-deep)]">
-                <CheckCircleIcon className="mt-0.5 h-5 w-5 shrink-0" />
+              <div className="flex items-start gap-3 rounded-[20px] border border-[var(--accent-border)] bg-[var(--accent-soft)] p-4 text-[var(--accent)]">
                 <div className="space-y-1">
-                  <p className="text-sm font-bold">Upload complete</p>
+                  <p className="text-sm font-bold">Upload received</p>
                   <p className="text-sm font-medium text-[var(--muted-foreground)]">
-                    Your files have been uploaded successfully. Synchronization is continuing in the background.
+                    Your files were uploaded. Synchronization is continuing in the background.
                   </p>
                 </div>
               </div>
@@ -404,6 +403,7 @@ export default function Import() {
 }
 
 export function OximeterImportSummary({ result }: { result: OximeterImportResponse }) {
+  const hasFailures = result.status === 'failed' || result.status === 'partial'
   const groups: Array<{ status: OximeterImportResult['status']; label: string; className: string }> = [
     { status: 'imported', label: 'Imported', className: 'text-[var(--olive-deep)]' },
     { status: 'skipped', label: 'Skipped', className: 'text-[var(--muted-foreground)]' },
@@ -413,6 +413,16 @@ export function OximeterImportSummary({ result }: { result: OximeterImportRespon
 
   return (
     <div className="space-y-3 rounded-[20px] border border-[var(--border)] bg-[var(--surface-soft)] p-4">
+      {hasFailures ? (
+        <div className={`rounded-[14px] border px-3 py-2 text-sm font-bold ${
+          result.status === 'failed'
+            ? 'border-[rgba(176,58,46,0.28)] bg-[rgba(176,58,46,0.08)] text-[var(--danger-text)]'
+            : 'border-[rgba(233,120,75,0.28)] bg-[rgba(233,120,75,0.08)] text-[var(--orange-700)]'
+        }`}
+        >
+          {result.message}
+        </div>
+      ) : null}
       <div className="grid grid-cols-4 gap-2 text-center text-xs">
         <ResultCount label="Imported" value={result.imported} />
         <ResultCount label="Skipped" value={result.skipped} />

--- a/tests/test_oximeter_upload.py
+++ b/tests/test_oximeter_upload.py
@@ -1,10 +1,12 @@
 import uuid
 from datetime import UTC, date, datetime
+from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
 from sqlalchemy import text
 
 from api.oximeter import build_legacy_viatom_fixture
+from api.routers import upload
 
 
 def _seed_session(db, user_id: str, start: datetime | None = None) -> str:
@@ -43,6 +45,22 @@ def _fixture(started_at: datetime | None = None) -> bytes:
     )
 
 
+def test_datalog_import_failure_records_failed_status(monkeypatch):
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=2)
+
+    user_id = str(uuid.uuid4())
+    upload.IMPORT_JOBS.clear()
+    monkeypatch.setattr(upload.subprocess, "run", fake_run)
+
+    upload._run_import("DATALOG", user_id, None)
+
+    status = upload.IMPORT_JOBS[user_id]
+    assert status.running is False
+    assert status.status == "failed"
+    assert status.message == "Import failed. Check the uploaded files and try again."
+
+
 class TestOximeterUpload:
     def test_unauthenticated(self, client: TestClient):
         resp = client.post(
@@ -63,6 +81,7 @@ class TestOximeterUpload:
 
         assert resp.status_code == 200
         data = resp.json()
+        assert data["status"] == "completed"
         assert data["imported"] == 1
         assert data["results"][0]["session_id"] == sid
         assert data["results"][0]["sample_count"] == 2
@@ -93,7 +112,9 @@ class TestOximeterUpload:
         )
 
         assert resp.status_code == 200
-        assert resp.json()["unmatched"] == 1
+        data = resp.json()
+        assert data["status"] == "completed"
+        assert data["unmatched"] == 1
         assert db.execute(text("SELECT COUNT(*) FROM session_spo2")).scalar_one() == 0
 
     def test_existing_spo2_skips_by_default_and_overwrites_when_requested(
@@ -142,3 +163,38 @@ class TestOximeterUpload:
             {"sid": sid},
         ).mappings().all()
         assert [(row["spo2"], row["pulse"]) for row in rows] == [(95, 64)]
+
+    def test_unsupported_upload_returns_failed_status(self, client: TestClient, auth_headers):
+        resp = client.post(
+            "/upload/oximeter",
+            headers=auth_headers,
+            files=[("files", ("unsupported.bin", b"not a viatom file", "application/octet-stream"))],
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "failed"
+        assert data["message"] == "No oximeter files could be imported."
+        assert data["failed"] == 1
+        assert data["results"][0]["status"] == "failed"
+        assert "Traceback" not in data["results"][0]["message"]
+
+    def test_parser_exception_returns_safe_failed_status(self, client: TestClient, auth_headers, monkeypatch):
+        def raise_parser_error(*args, **kwargs):
+            raise RuntimeError("Traceback: database password at /internal/path")
+
+        monkeypatch.setattr(upload, "parse_viatom_binary", raise_parser_error)
+
+        resp = client.post(
+            "/upload/oximeter",
+            headers=auth_headers,
+            files=[("files", ("broken.bin", b"broken", "application/octet-stream"))],
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "failed"
+        assert data["failed"] == 1
+        assert data["results"][0]["message"] == "Could not import this oximeter file. Check the file and try again."
+        assert "Traceback" not in resp.text
+        assert "database password" not in resp.text


### PR DESCRIPTION
## Summary

- Record DATALOG background imports as `failed` when the importer subprocess exits non-zero
- Return upload/import `status` and a safe user-facing `message` from `/upload/status`
- Add top-level oximeter import status: `completed`, `partial`, or `failed`
- Convert unexpected oximeter parser/import exceptions into short safe failure rows
- Avoid exposing stack traces or sensitive backend internals to users
- Update the Import UI so upload completion alone is not shown as green success
- Surface failed background import status in the UI

## Scope

No schema changes, migrations, auth, AI integration, Docker, or settings changes.

Successful import behavior is preserved.

## Testing

Passed:

- `uv run ruff check api/routers/upload.py tests/test_oximeter_upload.py`
- `uv run pytest tests/test_oximeter_upload.py -q`
  - `1 passed, 6 skipped`
- `uv run pytest -q`
  - `38 passed, 70 skipped`
- `cd frontend && npm run test`
  - `6 passed`
- `cd frontend && npm run build`

Not run / blocked:

- Root `npm run lint`, `npm run typecheck`, and `npm run test` are unavailable because the root package scripts are missing.
- `cd frontend && npm run lint` still fails on existing repo-wide lint issues, including `react-hooks/set-state-in-effect`, `no-explicit-any`, and fast-refresh export warnings.

## LXC smoke test

Passed:

- Deployed `fix/import-job-status` at `afed224`
- App container rebuilt and healthy
- Postgres container healthy
- Successful DATALOG import completed: 54 session blocks across 31 nights
- Invalid DATALOG test was rejected as invalid instead of appearing successful
- Recent logs showed no new traceback, crash loop, or container restart
- `/upload/status` returns `401` from unauthenticated curl, which is expected because the endpoint requires browser auth