### PR TITLE
feat: add nightly session notes

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -34,6 +34,7 @@ class SessionSummary(BaseModel):
 class SessionDetail(SessionSummary):
     pld_start_datetime: datetime
     device_serial: Optional[str]
+    note: str | None = None
     avg_resp_rate: Optional[float]
     avg_tidal_vol: Optional[float]
     avg_min_vent: Optional[float]

--- a/api/routers/sessions.py
+++ b/api/routers/sessions.py
@@ -18,6 +18,10 @@ class SessionTimezoneUpdate(BaseModel):
     machine_tz: str
 
 
+class SessionNoteUpdate(BaseModel):
+    note: str | None = None
+
+
 @router.get("/", response_model=List[SessionSummary])
 def list_sessions(
     page: int = Query(1, ge=1),
@@ -129,7 +133,8 @@ def get_session(
                 (array_agg(s.mask_type       ORDER BY s.duration_seconds DESC))[1] AS mask_type,
                 (array_agg(s.humidity_level  ORDER BY s.duration_seconds DESC))[1] AS humidity_level,
                 (array_agg(s.temperature_c   ORDER BY s.duration_seconds DESC))[1] AS temperature_c,
-                (array_agg(s.machine_tz      ORDER BY s.duration_seconds DESC))[1] AS machine_tz
+                (array_agg(s.machine_tz      ORDER BY s.duration_seconds DESC))[1] AS machine_tz,
+                (array_agg(s.note            ORDER BY s.duration_seconds DESC))[1] AS note
             FROM sessions s
             JOIN night n ON s.folder_date = n.folder_date AND s.user_id = n.user_id
             WHERE s.duration_seconds >= 600
@@ -140,6 +145,43 @@ def get_session(
     if not row:
         raise HTTPException(status_code=404, detail="Session not found")
     return SessionDetail.model_validate(dict(row))
+
+
+@router.put("/{session_id}/note", response_model=SessionDetail)
+def update_session_note(
+    session_id: str,
+    body: SessionNoteUpdate,
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    selected = db.execute(
+        text("""
+            SELECT folder_date
+            FROM sessions
+            WHERE id::text = :id
+              AND user_id = CAST(:uid AS uuid)
+        """),
+        {"id": session_id, "uid": current_user["id"]},
+    ).mappings().first()
+    if not selected:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    note = body.note.strip() if body.note is not None else None
+    if note == "":
+        note = None
+
+    db.execute(
+        text("""
+            UPDATE sessions
+            SET note = :note,
+                updated_at = NOW()
+            WHERE user_id = CAST(:uid AS uuid)
+              AND folder_date = :folder_date
+        """),
+        {"note": note, "uid": current_user["id"], "folder_date": selected["folder_date"]},
+    )
+    db.commit()
+    return get_session(session_id=session_id, current_user=current_user, db=db)
 
 
 @router.get("/{session_id}/events", response_model=List[EventRecord])
@@ -564,7 +606,9 @@ def get_session_by_date(
                 (array_agg(s.therapy_mode    ORDER BY s.duration_seconds DESC))[1] AS therapy_mode,
                 (array_agg(s.mask_type       ORDER BY s.duration_seconds DESC))[1] AS mask_type,
                 (array_agg(s.humidity_level  ORDER BY s.duration_seconds DESC))[1] AS humidity_level,
-                (array_agg(s.temperature_c   ORDER BY s.duration_seconds DESC))[1] AS temperature_c
+                (array_agg(s.temperature_c   ORDER BY s.duration_seconds DESC))[1] AS temperature_c,
+                (array_agg(s.machine_tz      ORDER BY s.duration_seconds DESC))[1] AS machine_tz,
+                (array_agg(s.note            ORDER BY s.duration_seconds DESC))[1] AS note
             FROM sessions s
             JOIN night n ON s.folder_date = n.folder_date AND s.user_id = n.user_id
             WHERE s.duration_seconds >= 600

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -149,6 +149,7 @@ export interface SessionSummary {
 export interface SessionDetail extends SessionSummary {
   pld_start_datetime: string
   device_serial: string | null
+  note: string | null
   avg_resp_rate: number | null
   avg_tidal_vol: number | null
   avg_min_vent: number | null
@@ -434,6 +435,8 @@ export const api = {
     get<SessionSummary[]>('/sessions/', params as Record<string, string | number> | undefined),
   getSession: (id: string) => get<SessionDetail>(`/sessions/${id}`),
   getSessionByDate: (date: string) => get<SessionDetail>(`/sessions/by-date/${date}`),
+  updateSessionNote: (id: string, note: string) =>
+    put<SessionDetail>(`/sessions/${id}/note`, { note }),
   updateSessionTimezone: (id: string, machineTz: string) =>
     put<SessionDetail>(`/sessions/${id}/timezone`, { machine_tz: machineTz }),
   getEvents: (id: string) => get<EventRecord[]>(`/sessions/${id}/events`),

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -79,6 +79,10 @@ export default function SessionDetail() {
   const [timezoneError, setTimezoneError] = useState<string | null>(null)
   const [isTimezoneSubmitting, setIsTimezoneSubmitting] = useState(false)
   const [isTimezoneEditorOpen, setIsTimezoneEditorOpen] = useState(false)
+  const [noteDraft, setNoteDraft] = useState('')
+  const [noteMessage, setNoteMessage] = useState<string | null>(null)
+  const [noteError, setNoteError] = useState<string | null>(null)
+  const [isNoteSubmitting, setIsNoteSubmitting] = useState(false)
   const [selectedEventId, setSelectedEventId] = useState<number | null>(null)
   const [eventWindow, setEventWindow] = useState<EventWindowResponse | null>(null)
   const [eventWindowLoading, setEventWindowLoading] = useState(false)
@@ -93,6 +97,8 @@ export default function SessionDetail() {
     setTimezoneMessage(null)
     setTimezoneError(null)
     setIsTimezoneEditorOpen(false)
+    setNoteMessage(null)
+    setNoteError(null)
     setSelectedEventId(null)
     setEventWindow(null)
     setEventWindowLoading(false)
@@ -102,6 +108,7 @@ export default function SessionDetail() {
     ]).then(([s]) => {
       setSession(s)
       setTimezoneDraft(s.machine_tz ?? '')
+      setNoteDraft(s.note ?? '')
       return Promise.all([
         api.getEvents(s.id),
         api.getMetrics(s.id, 15),
@@ -237,6 +244,24 @@ export default function SessionDetail() {
       setTimezoneError(err instanceof Error ? err.message : 'Could not update session timezone')
     } finally {
       setIsTimezoneSubmitting(false)
+    }
+  }
+
+  async function handleNoteSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!session) return
+    setNoteError(null)
+    setNoteMessage(null)
+    setIsNoteSubmitting(true)
+    try {
+      const updated = await api.updateSessionNote(session.id, noteDraft)
+      setSession(updated)
+      setNoteDraft(updated.note ?? '')
+      setNoteMessage(updated.note ? 'Note saved.' : 'Note cleared.')
+    } catch (err) {
+      setNoteError(err instanceof Error ? err.message : 'Could not save note')
+    } finally {
+      setIsNoteSubmitting(false)
     }
   }
 
@@ -482,6 +507,38 @@ export default function SessionDetail() {
           </CardContent>
         </Card>
       )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Notes</CardTitle>
+          <CardDescription>{session.note ? 'Saved note for this night.' : 'No notes yet.'}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-3" onSubmit={handleNoteSubmit}>
+            <Label htmlFor="sessionNote">Session note</Label>
+            <textarea
+              id="sessionNote"
+              value={noteDraft}
+              onChange={(event) => {
+                setNoteDraft(event.target.value)
+                setNoteError(null)
+                setNoteMessage(null)
+              }}
+              className="min-h-28 w-full resize-y rounded-[14px] border border-[var(--border)] bg-[var(--surface-soft)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition placeholder:text-[var(--muted-foreground)] focus:border-[var(--accent-border)] focus:ring-2 focus:ring-[rgba(82,81,167,0.16)]"
+              placeholder="Tried mouth tape, had a late drink, felt congested..."
+            />
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                {noteMessage ? <p className="text-sm font-medium text-[var(--olive-deep)]">{noteMessage}</p> : null}
+                {noteError ? <p className="text-sm text-[var(--danger-text)]">{noteError}</p> : null}
+              </div>
+              <Button type="submit" disabled={isNoteSubmitting}>
+                {isNoteSubmitting ? 'Saving...' : 'Save note'}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
 
       <SessionAICard sessionId={session.id} />
 

--- a/migrations/018_add_session_note.sql
+++ b/migrations/018_add_session_note.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS note TEXT;
+
+COMMIT;

--- a/schema.sql
+++ b/schema.sql
@@ -37,6 +37,7 @@ CREATE TABLE sessions (
     has_spo2                BOOLEAN NOT NULL DEFAULT FALSE,
     avg_spo2                NUMERIC(5,1),
     min_spo2                NUMERIC(5,1),
+    note                    TEXT,
     created_at              TIMESTAMPTZ DEFAULT NOW(),
     updated_at              TIMESTAMPTZ DEFAULT NOW()
 );

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import text
 
 
-def _seed_session(db, user_id: str, folder_date: date | None = None):
+def _seed_session(db, user_id: str, folder_date: date | None = None, note: str | None = None):
     if folder_date is None:
         folder_date = date.today()
     session_id = str(uuid.uuid4())
@@ -13,10 +13,10 @@ def _seed_session(db, user_id: str, folder_date: date | None = None):
         text("""
             INSERT INTO sessions (
                 id, session_id, folder_date, start_datetime, pld_start_datetime,
-                duration_seconds, device_serial, has_spo2, user_id
+                duration_seconds, device_serial, has_spo2, user_id, note
             ) VALUES (
                 CAST(:sid AS uuid), :sid, :fd, :start, :start,
-                28800, 'SN12345', FALSE, CAST(:uid AS uuid)
+                28800, 'SN12345', FALSE, CAST(:uid AS uuid), :note
             )
         """),
         {
@@ -24,6 +24,7 @@ def _seed_session(db, user_id: str, folder_date: date | None = None):
             "fd": folder_date,
             "start": datetime(2025, 1, 15, 22, 0, 0, tzinfo=UTC),
             "uid": user_id,
+            "note": note,
         },
     )
     db.commit()
@@ -58,8 +59,58 @@ class TestGetSession:
         assert data.get("humidity_level") is None
         assert data.get("temperature_c") is None
         assert data.get("machine_tz") is None
+        assert data.get("note") is None
+
+    def test_get_detail_includes_note(self, client: TestClient, auth_headers, test_user, db):
+        sid = _seed_session(db, test_user["id"], note="Tried mouth tape")
+        resp = client.get(f"/sessions/{sid}", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["note"] == "Tried mouth tape"
 
     def test_get_nonexistent(self, client: TestClient, auth_headers):
         fake_id = "00000000-0000-0000-0000-000000000000"
         resp = client.get(f"/sessions/{fake_id}", headers=auth_headers)
         assert resp.status_code == 404
+
+
+class TestSessionNotes:
+    def test_save_note_persists(self, client: TestClient, auth_headers, test_user, db):
+        sid = _seed_session(db, test_user["id"])
+        resp = client.put(f"/sessions/{sid}/note", headers=auth_headers, json={"note": "Had 2 beers"})
+        assert resp.status_code == 200
+        assert resp.json()["note"] == "Had 2 beers"
+
+        detail = client.get(f"/sessions/{sid}", headers=auth_headers)
+        assert detail.status_code == 200
+        assert detail.json()["note"] == "Had 2 beers"
+
+    def test_update_note_replaces_existing_note(self, client: TestClient, auth_headers, test_user, db):
+        sid = _seed_session(db, test_user["id"], note="Old mask")
+        resp = client.put(f"/sessions/{sid}/note", headers=auth_headers, json={"note": "New mask cushion"})
+        assert resp.status_code == 200
+        assert resp.json()["note"] == "New mask cushion"
+
+    def test_whitespace_note_clears_existing_note(self, client: TestClient, auth_headers, test_user, db):
+        sid = _seed_session(db, test_user["id"], note="Felt congested")
+        resp = client.put(f"/sessions/{sid}/note", headers=auth_headers, json={"note": "   "})
+        assert resp.status_code == 200
+        assert resp.json()["note"] is None
+
+        detail = client.get(f"/sessions/{sid}", headers=auth_headers)
+        assert detail.status_code == 200
+        assert detail.json()["note"] is None
+
+    def test_save_note_for_missing_session_returns_safe_error(self, client: TestClient, auth_headers):
+        fake_id = "00000000-0000-0000-0000-000000000000"
+        resp = client.put(f"/sessions/{fake_id}/note", headers=auth_headers, json={"note": "Used new pillow"})
+        assert resp.status_code == 404
+        assert resp.json() == {"detail": "Session not found"}
+
+    def test_invalid_note_payload_returns_validation_error(self, client: TestClient, auth_headers, test_user, db):
+        sid = _seed_session(db, test_user["id"], note="Keep my draft server-side")
+        resp = client.put(f"/sessions/{sid}/note", headers=auth_headers, json={"note": {"text": "not plain text"}})
+        assert resp.status_code == 422
+
+        detail = client.get(f"/sessions/{sid}", headers=auth_headers)
+        assert detail.status_code == 200
+        assert detail.json()["note"] == "Keep my draft server-side"


### PR DESCRIPTION
## Summary

Adds simple plain-text notes for SleepLab session/night detail pages.

Users can now add, edit, view, and clear an optional note for a sleep session/night. Notes are stored on the existing `sessions` table with a nullable `note` column.

Because SleepLab already treats `user_id + folder_date` as the nightly boundary, saving a note updates all session rows for that same user/night so multi-block nights stay consistent.

## Changes

- Added migration `018_add_session_note.sql`
- Extended session detail API response with `note`
- Added `PUT /sessions/{session_id}/note`
- Added a compact Notes section to `SessionDetail.tsx`
- Added backend tests for note persistence, updating, clearing, and session detail response

## Screenshot

Notes section on the session detail page:

<img width="1285" height="356" alt="SleepLab session detail notes section" src="https://github.com/user-attachments/assets/6e6b507f-4e56-4fae-acaf-f86c3dd3ebe6" />

## Validation

- Migration applied successfully in local LXC deployment
- App rebuilt and started healthy
- Manual UI test passed: add note, save, refresh, edit, clear
- `uv run python scripts\check_migrations.py` passed
- `uv run pytest -q` passed available tests: `37 passed, 74 skipped`
- `npm run test` in `frontend` passed: `6 passed`
- `npm run build` in `frontend` passed
- `npm run lint` still has pre-existing repo-wide lint failures unrelated to this PR