### PR TITLE
feat: add session tags and tag insights

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, Field, computed_field
 from typing import Dict, List, Literal, Optional
 from datetime import datetime, date
 
@@ -35,6 +35,7 @@ class SessionDetail(SessionSummary):
     pld_start_datetime: datetime
     device_serial: Optional[str]
     note: str | None = None
+    tags: list[str] = Field(default_factory=list)
     avg_resp_rate: Optional[float]
     avg_tidal_vol: Optional[float]
     avg_min_vent: Optional[float]

--- a/api/models.py
+++ b/api/models.py
@@ -49,6 +49,14 @@ class SessionDetail(SessionSummary):
     temperature_c: Optional[float]
 
 
+class TagInsight(BaseModel):
+    tag: str
+    night_count: int
+    avg_ahi: Optional[float]
+    baseline_avg_ahi: Optional[float]
+    delta_ahi: Optional[float]
+
+
 class EventRecord(BaseModel):
     id: int
     event_type: str

--- a/api/routers/sessions.py
+++ b/api/routers/sessions.py
@@ -151,7 +151,15 @@ def get_session(
                 (array_agg(s.temperature_c   ORDER BY s.duration_seconds DESC))[1] AS temperature_c,
                 (array_agg(s.machine_tz      ORDER BY s.duration_seconds DESC))[1] AS machine_tz,
                 (array_agg(s.note            ORDER BY s.duration_seconds DESC))[1] AS note,
-                (array_agg(COALESCE(s.tags, ARRAY[]::text[]) ORDER BY s.duration_seconds DESC))[1] AS tags
+                COALESCE((
+                    SELECT s2.tags
+                    FROM sessions s2
+                    JOIN night n2 ON s2.folder_date = n2.folder_date AND s2.user_id = n2.user_id
+                    WHERE s2.duration_seconds >= 600
+                      AND s2.tags IS NOT NULL
+                    ORDER BY s2.duration_seconds DESC
+                    LIMIT 1
+                ), ARRAY[]::text[]) AS tags
             FROM sessions s
             JOIN night n ON s.folder_date = n.folder_date AND s.user_id = n.user_id
             WHERE s.duration_seconds >= 600
@@ -666,7 +674,15 @@ def get_session_by_date(
                 (array_agg(s.temperature_c   ORDER BY s.duration_seconds DESC))[1] AS temperature_c,
                 (array_agg(s.machine_tz      ORDER BY s.duration_seconds DESC))[1] AS machine_tz,
                 (array_agg(s.note            ORDER BY s.duration_seconds DESC))[1] AS note,
-                (array_agg(COALESCE(s.tags, ARRAY[]::text[]) ORDER BY s.duration_seconds DESC))[1] AS tags
+                COALESCE((
+                    SELECT s2.tags
+                    FROM sessions s2
+                    JOIN night n2 ON s2.folder_date = n2.folder_date AND s2.user_id = n2.user_id
+                    WHERE s2.duration_seconds >= 600
+                      AND s2.tags IS NOT NULL
+                    ORDER BY s2.duration_seconds DESC
+                    LIMIT 1
+                ), ARRAY[]::text[]) AS tags
             FROM sessions s
             JOIN night n ON s.folder_date = n.folder_date AND s.user_id = n.user_id
             WHERE s.duration_seconds >= 600

--- a/api/routers/sessions.py
+++ b/api/routers/sessions.py
@@ -28,6 +28,7 @@ ALLOWED_SESSION_TAGS = {
     "Sick",
     "New mask",
     "Mouth tape",
+    "Back sleeper",
     "Bad sleep",
     "Good sleep",
     "Camping",

--- a/api/routers/sessions.py
+++ b/api/routers/sessions.py
@@ -22,6 +22,22 @@ class SessionNoteUpdate(BaseModel):
     note: str | None = None
 
 
+ALLOWED_SESSION_TAGS = {
+    "Travel",
+    "Alcohol",
+    "Sick",
+    "New mask",
+    "Mouth tape",
+    "Bad sleep",
+    "Good sleep",
+    "Camping",
+}
+
+
+class SessionTagsUpdate(BaseModel):
+    tags: list[str]
+
+
 @router.get("/", response_model=List[SessionSummary])
 def list_sessions(
     page: int = Query(1, ge=1),
@@ -134,7 +150,8 @@ def get_session(
                 (array_agg(s.humidity_level  ORDER BY s.duration_seconds DESC))[1] AS humidity_level,
                 (array_agg(s.temperature_c   ORDER BY s.duration_seconds DESC))[1] AS temperature_c,
                 (array_agg(s.machine_tz      ORDER BY s.duration_seconds DESC))[1] AS machine_tz,
-                (array_agg(s.note            ORDER BY s.duration_seconds DESC))[1] AS note
+                (array_agg(s.note            ORDER BY s.duration_seconds DESC))[1] AS note,
+                (array_agg(COALESCE(s.tags, ARRAY[]::text[]) ORDER BY s.duration_seconds DESC))[1] AS tags
             FROM sessions s
             JOIN night n ON s.folder_date = n.folder_date AND s.user_id = n.user_id
             WHERE s.duration_seconds >= 600
@@ -179,6 +196,46 @@ def update_session_note(
               AND folder_date = :folder_date
         """),
         {"note": note, "uid": current_user["id"], "folder_date": selected["folder_date"]},
+    )
+    db.commit()
+    return get_session(session_id=session_id, current_user=current_user, db=db)
+
+
+@router.put("/{session_id}/tags", response_model=SessionDetail)
+def update_session_tags(
+    session_id: str,
+    body: SessionTagsUpdate,
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    selected = db.execute(
+        text("""
+            SELECT folder_date
+            FROM sessions
+            WHERE id::text = :id
+              AND user_id = CAST(:uid AS uuid)
+        """),
+        {"id": session_id, "uid": current_user["id"]},
+    ).mappings().first()
+    if not selected:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    tags = []
+    for tag in body.tags:
+        if tag not in ALLOWED_SESSION_TAGS:
+            raise HTTPException(status_code=422, detail=f"Invalid session tag: {tag}")
+        if tag not in tags:
+            tags.append(tag)
+
+    db.execute(
+        text("""
+            UPDATE sessions
+            SET tags = CAST(:tags AS text[]),
+                updated_at = NOW()
+            WHERE user_id = CAST(:uid AS uuid)
+              AND folder_date = :folder_date
+        """),
+        {"tags": tags, "uid": current_user["id"], "folder_date": selected["folder_date"]},
     )
     db.commit()
     return get_session(session_id=session_id, current_user=current_user, db=db)
@@ -608,7 +665,8 @@ def get_session_by_date(
                 (array_agg(s.humidity_level  ORDER BY s.duration_seconds DESC))[1] AS humidity_level,
                 (array_agg(s.temperature_c   ORDER BY s.duration_seconds DESC))[1] AS temperature_c,
                 (array_agg(s.machine_tz      ORDER BY s.duration_seconds DESC))[1] AS machine_tz,
-                (array_agg(s.note            ORDER BY s.duration_seconds DESC))[1] AS note
+                (array_agg(s.note            ORDER BY s.duration_seconds DESC))[1] AS note,
+                (array_agg(COALESCE(s.tags, ARRAY[]::text[]) ORDER BY s.duration_seconds DESC))[1] AS tags
             FROM sessions s
             JOIN night n ON s.folder_date = n.folder_date AND s.user_id = n.user_id
             WHERE s.duration_seconds >= 600

--- a/api/routers/sessions.py
+++ b/api/routers/sessions.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional
 
 from ..auth import get_current_user
 from ..database import get_db
-from ..models import SessionSummary, SessionDetail, EventRecord, MetricsResponse, SpO2Response, EquipmentResponse, InferredEquipment, WaveformResponse, EventWindowResponse
+from ..models import SessionSummary, SessionDetail, TagInsight, EventRecord, MetricsResponse, SpO2Response, EquipmentResponse, InferredEquipment, WaveformResponse, EventWindowResponse
 
 router = APIRouter()
 
@@ -100,6 +100,77 @@ def list_sessions(
     """)
     rows = db.execute(sql, params).mappings().all()
     return [SessionSummary.model_validate(dict(r)) for r in rows]
+
+
+@router.get("/tag-insights", response_model=List[TagInsight])
+def get_tag_insights(
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    rows = db.execute(
+        text("""
+            WITH night_metric AS (
+                SELECT
+                    user_id,
+                    folder_date,
+                    CASE
+                        WHEN SUM(duration_seconds) > 0
+                        THEN ROUND((SUM(total_ahi_events) / (SUM(duration_seconds) / 3600.0))::numeric, 2)
+                        ELSE NULL
+                    END AS ahi
+                FROM sessions
+                WHERE user_id = CAST(:uid AS uuid)
+                  AND folder_date >= CURRENT_DATE - INTERVAL '90 days'
+                  AND duration_seconds >= 600
+                GROUP BY user_id, folder_date
+            ),
+            night AS (
+                SELECT
+                    night_metric.user_id,
+                    night_metric.folder_date,
+                    night_metric.ahi,
+                    COALESCE((
+                        SELECT s2.tags
+                        FROM sessions s2
+                        WHERE s2.user_id = night_metric.user_id
+                          AND s2.folder_date = night_metric.folder_date
+                          AND s2.duration_seconds >= 600
+                          AND s2.tags IS NOT NULL
+                        ORDER BY s2.duration_seconds DESC
+                        LIMIT 1
+                    ), ARRAY[]::text[]) AS tags
+                FROM night_metric
+            ),
+            baseline AS (
+                SELECT ROUND(AVG(ahi)::numeric, 2) AS baseline_avg_ahi
+                FROM night
+            ),
+            tagged AS (
+                SELECT
+                    tag,
+                    COUNT(*) AS night_count,
+                    ROUND(AVG(ahi)::numeric, 2) AS avg_ahi
+                FROM night
+                CROSS JOIN LATERAL unnest(tags) AS tag
+                GROUP BY tag
+                HAVING COUNT(*) >= 2
+            )
+            SELECT
+                tagged.tag,
+                tagged.night_count,
+                tagged.avg_ahi,
+                baseline.baseline_avg_ahi,
+                CASE
+                    WHEN tagged.avg_ahi IS NULL OR baseline.baseline_avg_ahi IS NULL THEN NULL
+                    ELSE ROUND((tagged.avg_ahi - baseline.baseline_avg_ahi)::numeric, 2)
+                END AS delta_ahi
+            FROM tagged
+            CROSS JOIN baseline
+            ORDER BY tagged.tag
+        """),
+        {"uid": current_user["id"]},
+    ).mappings().all()
+    return [TagInsight.model_validate(dict(r)) for r in rows]
 
 
 @router.get("/{session_id}", response_model=SessionDetail)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -150,6 +150,7 @@ export interface SessionDetail extends SessionSummary {
   pld_start_datetime: string
   device_serial: string | null
   note: string | null
+  tags: string[]
   avg_resp_rate: number | null
   avg_tidal_vol: number | null
   avg_min_vent: number | null
@@ -437,6 +438,8 @@ export const api = {
   getSessionByDate: (date: string) => get<SessionDetail>(`/sessions/by-date/${date}`),
   updateSessionNote: (id: string, note: string) =>
     put<SessionDetail>(`/sessions/${id}/note`, { note }),
+  updateSessionTags: (id: string, tags: string[]) =>
+    put<SessionDetail>(`/sessions/${id}/tags`, { tags }),
   updateSessionTimezone: (id: string, machineTz: string) =>
     put<SessionDetail>(`/sessions/${id}/timezone`, { machine_tz: machineTz }),
   getEvents: (id: string) => get<EventRecord[]>(`/sessions/${id}/events`),

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -164,6 +164,14 @@ export interface SessionDetail extends SessionSummary {
   temperature_c: number | null
 }
 
+export interface TagInsight {
+  tag: string
+  night_count: number
+  avg_ahi: number | null
+  baseline_avg_ahi: number | null
+  delta_ahi: number | null
+}
+
 export type EquipmentType = 'cushion' | 'headgear' | 'tubing' | 'humidifier_chamber' | 'filter'
 
 export interface Equipment {
@@ -436,6 +444,7 @@ export const api = {
     get<SessionSummary[]>('/sessions/', params as Record<string, string | number> | undefined),
   getSession: (id: string) => get<SessionDetail>(`/sessions/${id}`),
   getSessionByDate: (date: string) => get<SessionDetail>(`/sessions/by-date/${date}`),
+  getTagInsights: () => get<TagInsight[]>('/sessions/tag-insights'),
   updateSessionNote: (id: string, note: string) =>
     put<SessionDetail>(`/sessions/${id}/note`, { note }),
   updateSessionTags: (id: string, tags: string[]) =>

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -4,6 +4,7 @@ export const SESSION_TAGS = [
   'Sick',
   'New mask',
   'Mouth tape',
+  'Back sleeper',
   'Bad sleep',
   'Good sleep',
   'Camping',

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,0 +1,10 @@
+export const SESSION_TAGS = [
+  'Travel',
+  'Alcohol',
+  'Sick',
+  'New mask',
+  'Mouth tape',
+  'Bad sleep',
+  'Good sleep',
+  'Camping',
+] as const

--- a/frontend/src/pages/Insights.tsx
+++ b/frontend/src/pages/Insights.tsx
@@ -1,13 +1,18 @@
 import { useEffect, useState } from 'react'
 
-import type { SummaryStats } from '../api/client'
+import type { SummaryStats, TagInsight } from '../api/client'
 import { api } from '../api/client'
 import AISummaryCard from '../components/AISummaryCard'
 import { IMPORT_COMPLETED_EVENT } from '../lib/aiSummaryCache'
-import { Card, CardContent } from '../components/ui/card'
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card'
+
+function formatAhi(value: number | null) {
+  return value == null ? 'N/A' : value.toFixed(1)
+}
 
 export default function InsightsPage() {
   const [summary, setSummary] = useState<SummaryStats | null>(null)
+  const [tagInsights, setTagInsights] = useState<TagInsight[]>([])
   const [aiConfigured, setAiConfigured] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -15,11 +20,13 @@ export default function InsightsPage() {
   useEffect(() => {
     async function loadSummary() {
       try {
-        const [data, settings] = await Promise.all([
+        const [data, settings, tags] = await Promise.all([
           api.getSummary(),
           api.getImportSettings(),
+          api.getTagInsights(),
         ])
         setSummary(data)
+        setTagInsights(tags)
         setAiConfigured(settings.llm_configured)
         setError(null)
       } catch (err) {
@@ -66,6 +73,57 @@ export default function InsightsPage() {
           </CardContent>
         </Card> : null}
       </div>
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--foreground)]">Tag Insights</h2>
+          <p className="mt-1 text-sm text-[var(--muted-foreground)]">Average AHI by tags used on at least two recent nights.</p>
+        </div>
+        {tagInsights.length ? (
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {tagInsights.map((insight) => {
+              const lowerOrEqual = insight.delta_ahi == null || insight.delta_ahi <= 0
+              return (
+                <Card key={insight.tag}>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="flex items-center justify-between gap-3 text-base">
+                      <span>{insight.tag}</span>
+                      <span className="rounded-full bg-[var(--surface-soft)] px-2.5 py-1 text-xs font-bold text-[var(--muted-foreground)]">
+                        {insight.night_count} nights
+                      </span>
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="grid grid-cols-2 gap-3 text-sm">
+                      <div>
+                        <p className="text-xs font-bold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">Tagged AHI</p>
+                        <p className="mt-1 text-2xl font-semibold text-[var(--foreground)]">{formatAhi(insight.avg_ahi)}</p>
+                      </div>
+                      <div>
+                        <p className="text-xs font-bold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">Baseline</p>
+                        <p className="mt-1 text-2xl font-semibold text-[var(--foreground)]">{formatAhi(insight.baseline_avg_ahi)}</p>
+                      </div>
+                    </div>
+                    <div className={`rounded-[12px] px-3 py-2 text-sm font-bold ${
+                      lowerOrEqual
+                        ? 'bg-[rgba(106,161,54,0.12)] text-[var(--green-700)]'
+                        : 'bg-[var(--danger-soft)] text-[var(--danger-text)]'
+                    }`}>
+                      {lowerOrEqual ? '↓' : '↑'} {formatAhi(insight.delta_ahi == null ? null : Math.abs(insight.delta_ahi))} vs baseline
+                    </div>
+                  </CardContent>
+                </Card>
+              )
+            })}
+          </div>
+        ) : (
+          <Card>
+            <CardContent className="px-6 py-5 text-sm text-[var(--muted-foreground)]">
+              Tag at least two nights from a session detail page to see tag insights.
+            </CardContent>
+          </Card>
+        )}
+      </section>
 
       <AISummaryCard enabled={summary.nights_with_data > 0} />
     </div>

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -34,6 +34,13 @@ function ahiBadge(ahi: number | null): { label: string; className: string } {
   return { label: 'Difficult night', className: 'bg-[var(--danger-soft)] text-[var(--danger-text)]' }
 }
 
+function sameTags(a: string[], b: string[]) {
+  if (a.length !== b.length) return false
+  const left = [...a].sort()
+  const right = [...b].sort()
+  return left.every((tag, index) => tag === right[index])
+}
+
 const EVENT_WINDOW_PRESETS: Record<number, { before: number; after: number }> = {
   1: { before: 30, after: 30 },
   3: { before: 60, after: 120 },
@@ -308,6 +315,7 @@ export default function SessionDetail() {
   const mins  = Math.floor((session.duration_seconds % 3600) / 60)
   const endTime = new Date(new Date(session.start_datetime).getTime() + session.duration_seconds * 1000).toISOString()
   const badge = ahiBadge(session.ahi)
+  const tagsChanged = !sameTags(tagsDraft, session.tags ?? [])
 
   const statHelp = {
     ahi: 'AHI means apnea-hypopnea index: the average number of breathing events per hour during this session.',
@@ -551,15 +559,15 @@ export default function SessionDetail() {
         </CardHeader>
         <CardContent>
           <form className="space-y-4" onSubmit={handleTagsSubmit}>
-            <div className="flex flex-wrap gap-2">
-              {tagsDraft.length ? tagsDraft.map((tag) => (
-                <span key={tag} className="rounded-full bg-[rgba(82,81,167,0.10)] px-3 py-1 text-xs font-bold text-[var(--accent)]">
-                  {tag}
-                </span>
-              )) : (
-                <p className="text-sm text-[var(--muted-foreground)]">No tags added.</p>
-              )}
-            </div>
+            {tagsDraft.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {tagsDraft.map((tag) => (
+                  <span key={tag} className="rounded-full bg-[rgba(82,81,167,0.10)] px-3 py-1 text-xs font-bold text-[var(--accent)]">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            ) : null}
             <div className="flex flex-wrap gap-2">
               {SESSION_TAGS.map((tag) => {
                 const selected = tagsDraft.includes(tag)
@@ -571,7 +579,7 @@ export default function SessionDetail() {
                     className={`rounded-full border px-3 py-1.5 text-xs font-bold transition ${
                       selected
                         ? 'border-[var(--accent-border)] bg-[rgba(82,81,167,0.12)] text-[var(--accent)]'
-                        : 'border-[var(--border)] bg-[var(--surface-soft)] text-[var(--muted-foreground)] hover:border-[var(--accent-border)] hover:text-[var(--accent)]'
+                        : 'border-[var(--border)] bg-[var(--surface-soft)] text-[var(--foreground)] shadow-sm hover:border-[var(--accent-border)] hover:text-[var(--accent)]'
                     }`}
                     aria-pressed={selected}
                   >
@@ -585,7 +593,7 @@ export default function SessionDetail() {
                 {tagsMessage ? <p className="text-sm font-medium text-[var(--olive-deep)]">{tagsMessage}</p> : null}
                 {tagsError ? <p className="text-sm text-[var(--danger-text)]">{tagsError}</p> : null}
               </div>
-              <Button type="submit" disabled={isTagsSubmitting}>
+              <Button type="submit" disabled={isTagsSubmitting || !tagsChanged}>
                 {isTagsSubmitting ? 'Saving...' : 'Save tags'}
               </Button>
             </div>

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -61,6 +61,17 @@ const EVENT_COLORS: Record<string, string> = {
   'Arousal': '#6AA136',
 }
 
+const SESSION_TAGS = [
+  'Travel',
+  'Alcohol',
+  'Sick',
+  'New mask',
+  'Mouth tape',
+  'Bad sleep',
+  'Good sleep',
+  'Camping',
+]
+
 export default function SessionDetail() {
   const { date } = useParams<{ date: string }>()
   const navigate = useNavigate()
@@ -83,6 +94,10 @@ export default function SessionDetail() {
   const [noteMessage, setNoteMessage] = useState<string | null>(null)
   const [noteError, setNoteError] = useState<string | null>(null)
   const [isNoteSubmitting, setIsNoteSubmitting] = useState(false)
+  const [tagsDraft, setTagsDraft] = useState<string[]>([])
+  const [tagsMessage, setTagsMessage] = useState<string | null>(null)
+  const [tagsError, setTagsError] = useState<string | null>(null)
+  const [isTagsSubmitting, setIsTagsSubmitting] = useState(false)
   const [selectedEventId, setSelectedEventId] = useState<number | null>(null)
   const [eventWindow, setEventWindow] = useState<EventWindowResponse | null>(null)
   const [eventWindowLoading, setEventWindowLoading] = useState(false)
@@ -99,6 +114,8 @@ export default function SessionDetail() {
     setIsTimezoneEditorOpen(false)
     setNoteMessage(null)
     setNoteError(null)
+    setTagsMessage(null)
+    setTagsError(null)
     setSelectedEventId(null)
     setEventWindow(null)
     setEventWindowLoading(false)
@@ -109,6 +126,7 @@ export default function SessionDetail() {
       setSession(s)
       setTimezoneDraft(s.machine_tz ?? '')
       setNoteDraft(s.note ?? '')
+      setTagsDraft(s.tags ?? [])
       return Promise.all([
         api.getEvents(s.id),
         api.getMetrics(s.id, 15),
@@ -263,6 +281,34 @@ export default function SessionDetail() {
     } finally {
       setIsNoteSubmitting(false)
     }
+  }
+
+  async function handleTagsSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!session) return
+    setTagsError(null)
+    setTagsMessage(null)
+    setIsTagsSubmitting(true)
+    try {
+      const updated = await api.updateSessionTags(session.id, tagsDraft)
+      setSession(updated)
+      setTagsDraft(updated.tags ?? [])
+      setTagsMessage(updated.tags.length ? 'Tags saved.' : 'Tags cleared.')
+    } catch (err) {
+      setTagsError(err instanceof Error ? err.message : 'Could not save tags')
+    } finally {
+      setIsTagsSubmitting(false)
+    }
+  }
+
+  function toggleTag(tag: string) {
+    setTagsDraft((current) => (
+      current.includes(tag)
+        ? current.filter((item) => item !== tag)
+        : [...current, tag]
+    ))
+    setTagsError(null)
+    setTagsMessage(null)
   }
 
   if (loading) return <div className="rounded-[28px] border border-[var(--border)] bg-[var(--surface-strong)] p-10 text-center text-[var(--muted-foreground)]">Loading session...</div>
@@ -507,6 +553,55 @@ export default function SessionDetail() {
           </CardContent>
         </Card>
       )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Tags</CardTitle>
+          <CardDescription>{session.tags.length ? 'Saved tags for this night.' : 'No tags added.'}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleTagsSubmit}>
+            <div className="flex flex-wrap gap-2">
+              {tagsDraft.length ? tagsDraft.map((tag) => (
+                <span key={tag} className="rounded-full bg-[rgba(82,81,167,0.10)] px-3 py-1 text-xs font-bold text-[var(--accent)]">
+                  {tag}
+                </span>
+              )) : (
+                <p className="text-sm text-[var(--muted-foreground)]">No tags added.</p>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {SESSION_TAGS.map((tag) => {
+                const selected = tagsDraft.includes(tag)
+                return (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => toggleTag(tag)}
+                    className={`rounded-full border px-3 py-1.5 text-xs font-bold transition ${
+                      selected
+                        ? 'border-[var(--accent-border)] bg-[rgba(82,81,167,0.12)] text-[var(--accent)]'
+                        : 'border-[var(--border)] bg-[var(--surface-soft)] text-[var(--muted-foreground)] hover:border-[var(--accent-border)] hover:text-[var(--accent)]'
+                    }`}
+                    aria-pressed={selected}
+                  >
+                    {tag}
+                  </button>
+                )
+              })}
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                {tagsMessage ? <p className="text-sm font-medium text-[var(--olive-deep)]">{tagsMessage}</p> : null}
+                {tagsError ? <p className="text-sm text-[var(--danger-text)]">{tagsError}</p> : null}
+              </div>
+              <Button type="submit" disabled={isTagsSubmitting}>
+                {isTagsSubmitting ? 'Saving...' : 'Save tags'}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader>

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -15,6 +15,7 @@ import { Button } from '../components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
+import { SESSION_TAGS } from '../lib/constants'
 
 function fmtDate(iso: string) {
   return new Date(iso).toLocaleDateString([], { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', timeZone: getDisplayTz() })
@@ -60,17 +61,6 @@ const EVENT_COLORS: Record<string, string> = {
   'Apnea': '#C9B715',
   'Arousal': '#6AA136',
 }
-
-const SESSION_TAGS = [
-  'Travel',
-  'Alcohol',
-  'Sick',
-  'New mask',
-  'Mouth tape',
-  'Bad sleep',
-  'Good sleep',
-  'Camping',
-]
 
 export default function SessionDetail() {
   const { date } = useParams<{ date: string }>()

--- a/migrations/019_add_session_tags.sql
+++ b/migrations/019_add_session_tags.sql
@@ -1,0 +1,3 @@
+-- Store fixed preset tags at the same nightly scope as session notes.
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS tags TEXT[];

--- a/schema.sql
+++ b/schema.sql
@@ -38,6 +38,7 @@ CREATE TABLE sessions (
     avg_spo2                NUMERIC(5,1),
     min_spo2                NUMERIC(5,1),
     note                    TEXT,
+    tags                    TEXT[],
     created_at              TIMESTAMPTZ DEFAULT NOW(),
     updated_at              TIMESTAMPTZ DEFAULT NOW()
 );

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -83,6 +83,34 @@ class TestGetSession:
         assert resp.status_code == 200
         assert resp.json()["tags"] == ["Travel", "Sick"]
 
+    def test_get_by_date_returns_empty_tags_when_null(self, client: TestClient, auth_headers, test_user, db):
+        folder_date = date(2025, 1, 17)
+        _seed_session(db, test_user["id"], folder_date=folder_date)
+        resp = client.get(f"/sessions/by-date/{folder_date.isoformat()}", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == []
+
+    def test_get_by_date_returns_empty_tags_when_cleared(self, client: TestClient, auth_headers, test_user, db):
+        folder_date = date(2025, 1, 18)
+        _seed_session(db, test_user["id"], folder_date=folder_date, tags=[])
+        resp = client.get(f"/sessions/by-date/{folder_date.isoformat()}", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == []
+
+    def test_get_by_date_returns_saved_tags(self, client: TestClient, auth_headers, test_user, db):
+        folder_date = date(2025, 1, 19)
+        _seed_session(db, test_user["id"], folder_date=folder_date, tags=["Mouth tape", "Good sleep"])
+        resp = client.get(f"/sessions/by-date/{folder_date.isoformat()}", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == ["Mouth tape", "Good sleep"]
+
+    def test_get_by_date_preserves_note(self, client: TestClient, auth_headers, test_user, db):
+        folder_date = date(2025, 1, 20)
+        _seed_session(db, test_user["id"], folder_date=folder_date, note="Still congested")
+        resp = client.get(f"/sessions/by-date/{folder_date.isoformat()}", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["note"] == "Still congested"
+
     def test_get_nonexistent(self, client: TestClient, auth_headers):
         fake_id = "00000000-0000-0000-0000-000000000000"
         resp = client.get(f"/sessions/{fake_id}", headers=auth_headers)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -5,7 +5,14 @@ from fastapi.testclient import TestClient
 from sqlalchemy import text
 
 
-def _seed_session(db, user_id: str, folder_date: date | None = None, note: str | None = None):
+def _seed_session(
+    db,
+    user_id: str,
+    folder_date: date | None = None,
+    note: str | None = None,
+    tags: list[str] | None = None,
+    duration_seconds: int = 28800,
+):
     if folder_date is None:
         folder_date = date.today()
     session_id = str(uuid.uuid4())
@@ -13,10 +20,10 @@ def _seed_session(db, user_id: str, folder_date: date | None = None, note: str |
         text("""
             INSERT INTO sessions (
                 id, session_id, folder_date, start_datetime, pld_start_datetime,
-                duration_seconds, device_serial, has_spo2, user_id, note
+                duration_seconds, device_serial, has_spo2, user_id, note, tags
             ) VALUES (
                 CAST(:sid AS uuid), :sid, :fd, :start, :start,
-                28800, 'SN12345', FALSE, CAST(:uid AS uuid), :note
+                :duration_seconds, 'SN12345', FALSE, CAST(:uid AS uuid), :note, CAST(:tags AS text[])
             )
         """),
         {
@@ -25,6 +32,8 @@ def _seed_session(db, user_id: str, folder_date: date | None = None, note: str |
             "start": datetime(2025, 1, 15, 22, 0, 0, tzinfo=UTC),
             "uid": user_id,
             "note": note,
+            "tags": tags,
+            "duration_seconds": duration_seconds,
         },
     )
     db.commit()
@@ -60,12 +69,19 @@ class TestGetSession:
         assert data.get("temperature_c") is None
         assert data.get("machine_tz") is None
         assert data.get("note") is None
+        assert data.get("tags") == []
 
     def test_get_detail_includes_note(self, client: TestClient, auth_headers, test_user, db):
         sid = _seed_session(db, test_user["id"], note="Tried mouth tape")
         resp = client.get(f"/sessions/{sid}", headers=auth_headers)
         assert resp.status_code == 200
         assert resp.json()["note"] == "Tried mouth tape"
+
+    def test_get_detail_includes_tags(self, client: TestClient, auth_headers, test_user, db):
+        sid = _seed_session(db, test_user["id"], tags=["Travel", "Sick"])
+        resp = client.get(f"/sessions/{sid}", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == ["Travel", "Sick"]
 
     def test_get_nonexistent(self, client: TestClient, auth_headers):
         fake_id = "00000000-0000-0000-0000-000000000000"
@@ -114,3 +130,61 @@ class TestSessionNotes:
         detail = client.get(f"/sessions/{sid}", headers=auth_headers)
         assert detail.status_code == 200
         assert detail.json()["note"] == "Keep my draft server-side"
+
+
+class TestSessionTags:
+    def test_save_tags_persists(self, client: TestClient, auth_headers, test_user, db):
+        sid = _seed_session(db, test_user["id"])
+        resp = client.put(f"/sessions/{sid}/tags", headers=auth_headers, json={"tags": ["Travel", "Alcohol"]})
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == ["Travel", "Alcohol"]
+
+        detail = client.get(f"/sessions/{sid}", headers=auth_headers)
+        assert detail.status_code == 200
+        assert detail.json()["tags"] == ["Travel", "Alcohol"]
+
+    def test_save_tags_applies_to_all_blocks_for_night(self, client: TestClient, auth_headers, test_user, db):
+        folder_date = date(2025, 1, 16)
+        shorter_sid = _seed_session(db, test_user["id"], folder_date=folder_date, duration_seconds=3600)
+        longer_sid = _seed_session(db, test_user["id"], folder_date=folder_date, duration_seconds=7200)
+
+        resp = client.put(f"/sessions/{shorter_sid}/tags", headers=auth_headers, json={"tags": ["New mask", "Good sleep"]})
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == ["New mask", "Good sleep"]
+
+        rows = db.execute(
+            text("""
+                SELECT tags
+                FROM sessions
+                WHERE user_id = CAST(:uid AS uuid)
+                  AND folder_date = :folder_date
+                ORDER BY duration_seconds
+            """),
+            {"uid": test_user["id"], "folder_date": folder_date},
+        ).mappings().all()
+        assert [row["tags"] for row in rows] == [["New mask", "Good sleep"], ["New mask", "Good sleep"]]
+
+        detail = client.get(f"/sessions/{longer_sid}", headers=auth_headers)
+        assert detail.status_code == 200
+        assert detail.json()["tags"] == ["New mask", "Good sleep"]
+
+    def test_clear_tags_with_empty_array(self, client: TestClient, auth_headers, test_user, db):
+        sid = _seed_session(db, test_user["id"], tags=["Camping"])
+        resp = client.put(f"/sessions/{sid}/tags", headers=auth_headers, json={"tags": []})
+        assert resp.status_code == 200
+        assert resp.json()["tags"] == []
+
+        detail = client.get(f"/sessions/{sid}", headers=auth_headers)
+        assert detail.status_code == 200
+        assert detail.json()["tags"] == []
+
+    def test_invalid_tag_is_rejected_without_partial_update(self, client: TestClient, auth_headers, test_user, db):
+        sid = _seed_session(db, test_user["id"], note="Keep note", tags=["Travel"])
+        resp = client.put(f"/sessions/{sid}/tags", headers=auth_headers, json={"tags": ["Travel", "Bookmark"]})
+        assert resp.status_code == 422
+        assert resp.json() == {"detail": "Invalid session tag: Bookmark"}
+
+        detail = client.get(f"/sessions/{sid}", headers=auth_headers)
+        assert detail.status_code == 200
+        assert detail.json()["tags"] == ["Travel"]
+        assert detail.json()["note"] == "Keep note"

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 
 from fastapi.testclient import TestClient
 from sqlalchemy import text
@@ -12,6 +12,7 @@ def _seed_session(
     note: str | None = None,
     tags: list[str] | None = None,
     duration_seconds: int = 28800,
+    total_ahi_events: int = 0,
 ):
     if folder_date is None:
         folder_date = date.today()
@@ -20,10 +21,10 @@ def _seed_session(
         text("""
             INSERT INTO sessions (
                 id, session_id, folder_date, start_datetime, pld_start_datetime,
-                duration_seconds, device_serial, has_spo2, user_id, note, tags
+                duration_seconds, device_serial, has_spo2, user_id, note, tags, total_ahi_events
             ) VALUES (
                 CAST(:sid AS uuid), :sid, :fd, :start, :start,
-                :duration_seconds, 'SN12345', FALSE, CAST(:uid AS uuid), :note, CAST(:tags AS text[])
+                :duration_seconds, 'SN12345', FALSE, CAST(:uid AS uuid), :note, CAST(:tags AS text[]), :total_ahi_events
             )
         """),
         {
@@ -34,6 +35,7 @@ def _seed_session(
             "note": note,
             "tags": tags,
             "duration_seconds": duration_seconds,
+            "total_ahi_events": total_ahi_events,
         },
     )
     db.commit()
@@ -216,3 +218,60 @@ class TestSessionTags:
         assert detail.status_code == 200
         assert detail.json()["tags"] == ["Travel"]
         assert detail.json()["note"] == "Keep note"
+
+
+class TestSessionTagInsights:
+    def test_tag_insights_use_nightly_counts_and_all_night_baseline(self, client: TestClient, auth_headers, test_user, db):
+        today = date.today()
+        multiblock_date = today - timedelta(days=3)
+
+        _seed_session(
+            db,
+            test_user["id"],
+            folder_date=multiblock_date,
+            tags=["Travel"],
+            duration_seconds=3600,
+            total_ahi_events=4,
+        )
+        _seed_session(
+            db,
+            test_user["id"],
+            folder_date=multiblock_date,
+            tags=["Travel"],
+            duration_seconds=3600,
+            total_ahi_events=6,
+        )
+        _seed_session(
+            db,
+            test_user["id"],
+            folder_date=today - timedelta(days=2),
+            tags=["Travel", "Sick"],
+            duration_seconds=3600,
+            total_ahi_events=25,
+        )
+        _seed_session(
+            db,
+            test_user["id"],
+            folder_date=today - timedelta(days=1),
+            duration_seconds=3600,
+            total_ahi_events=30,
+        )
+        _seed_session(
+            db,
+            test_user["id"],
+            folder_date=today - timedelta(days=120),
+            tags=["Travel"],
+            duration_seconds=3600,
+            total_ahi_events=100,
+        )
+
+        resp = client.get("/sessions/tag-insights", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert [row["tag"] for row in data] == ["Travel"]
+
+        travel = data[0]
+        assert travel["night_count"] == 2
+        assert travel["avg_ahi"] == 15.0
+        assert travel["baseline_avg_ahi"] == 20.0
+        assert travel["delta_ahi"] == -5.0


### PR DESCRIPTION
## Summary

Adds session tags and tag-based AHI insights.

- Added session tag storage and update support
- Added shared frontend `SESSION_TAGS`
- Added `GET /sessions/tag-insights`
- Aggregates sessions by night before calculating tag stats
- Shows only tags used on at least two nights
- Adds a Tag Insights section to the Insights page
- Polished the session tag controls:
  - removed duplicate empty-state text
  - disabled Save tags when there are no tag changes
  - improved unselected pill contrast
  - added the Back sleeper tag
- Added backend test coverage for tag inclusion, one-use exclusion, baseline behavior, and multi-block night counting

## Screenshot

Session detail tag controls with the new tag pills and disabled no-op save state:

<img width="1272" height="248" alt="Session detail tags card showing tag pills, Back sleeper tag, and disabled Save tags button" src="https://github.com/user-attachments/assets/d8b5c93c-8db3-468c-a271-c3735754fefb" />

## Validation

- `npm run build` passed
- `npm --workspace frontend run test` passed, 2 files / 6 tests
- `git diff --check` passed
- `uv run pytest tests/test_sessions.py` collected 20 tests, all skipped because no test database URL is configured

## Notes

- `npm run lint`, `npm run typecheck`, and `npm run test` are not available as root scripts
- `npm --workspace frontend run lint` was attempted as the closest frontend lint command, but failed on existing unrelated lint issues