### PR TITLE
fix(frontend): correct timezone display in metrics chart split view

### DIFF
--- a/frontend/src/components/MetricsChartSplit.tsx
+++ b/frontend/src/components/MetricsChartSplit.tsx
@@ -4,6 +4,7 @@ import {
 } from 'recharts'
 import { useState } from 'react'
 import type { MetricsResponse } from '../api/client'
+import { getDisplayTz } from '../lib/displayTz'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
 
 interface Props {
@@ -53,7 +54,7 @@ export default function MetricsChartSplit({ metrics }: Props) {
   }
 
   function fmtTs(ts: number) {
-    return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: getDisplayTz() })
   }
 
   const TICK_INTERVAL_MS = 30 * 60 * 1000


### PR DESCRIPTION
## Summary
- Fix timezone handling in MetricsChartSplit component
- Discovered during cpap-parser integration testing; extracted as independent fix

## Test Plan
- [ ] `cd frontend && npm run lint` passes (pre-existing lint failures are unrelated)
- [ ] `npx tsc --noEmit -p tsconfig.app.json` passes
- [ ] Verify metrics chart shows correct timestamps in non-UTC timezones