### PR TITLE
fix: therapy score manufacturer aggregation

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -9,6 +9,7 @@ class SessionSummary(BaseModel):
     folder_date: date
     block_index: int
     start_datetime: datetime
+    end_datetime: datetime | None = None
     duration_seconds: int
     ahi: Optional[float]
     central_apnea_count: int

--- a/api/routers/sessions.py
+++ b/api/routers/sessions.py
@@ -14,10 +14,8 @@ from sqlalchemy.orm import Session
 from ..auth import get_current_user
 from ..database import get_db
 from ..models import (
-    EquipmentResponse,
     EventRecord,
     EventWindowResponse,
-    InferredEquipment,
     MetricsResponse,
     SessionDetail,
     SessionSummary,
@@ -77,7 +75,7 @@ def _manufacturer_select_expression(db: Session) -> str:
         return (
             "COALESCE("
             "(array_agg(s.manufacturer ORDER BY s.duration_seconds DESC) "
-            "FILTER (WHERE s.manufacturer IS NOT NULL))[1], "
+            "FILTER (WHERE s.manufacturer IS NOT NULL AND s.manufacturer <> ''))[1], "
             "'Unknown'"
             ") AS manufacturer"
         )
@@ -465,6 +463,7 @@ def list_sessions(
                 (array_agg(id::text ORDER BY duration_seconds DESC))[1] AS id,
                 (array_agg(session_id ORDER BY duration_seconds DESC))[1] AS session_id,
                 MIN(start_datetime) AS start_datetime,
+                MAX(start_datetime + (duration_seconds || ' seconds')::interval) AS end_datetime,
                 0 AS block_index,
                 SUM(duration_seconds) AS duration_seconds,
                 SUM(total_ahi_events) AS total_ahi_events,
@@ -488,7 +487,7 @@ def list_sessions(
             {"AND" if where else "WHERE"} duration_seconds >= 600
             GROUP BY folder_date
         )
-        SELECT id, session_id, folder_date, block_index, start_datetime, duration_seconds,
+        SELECT id, session_id, folder_date, block_index, start_datetime, end_datetime, duration_seconds,
                ahi, central_apnea_count, obstructive_apnea_count, hypopnea_count,
                apnea_count, arousal_count, total_ahi_events,
                avg_pressure, p95_pressure, avg_leak, has_spo2, machine_tz
@@ -578,8 +577,10 @@ def get_session(
     db: Session = Depends(get_db),
 ):
     """Full session detail — aggregated across all blocks for the night."""
+    manufacturer_select = _manufacturer_select_expression(db)
+
     row = db.execute(
-        text("""
+        text(f"""
             WITH night AS (
                 SELECT folder_date, user_id
                 FROM sessions
@@ -591,6 +592,7 @@ def get_session(
                 s.folder_date,
                 0 AS block_index,
                 MIN(s.start_datetime) AS start_datetime,
+                MAX(s.start_datetime + (s.duration_seconds || ' seconds')::interval) AS end_datetime,
                 MIN(s.start_datetime) AS pld_start_datetime,
                 SUM(s.duration_seconds) AS duration_seconds,
                 SUM(s.total_ahi_events) AS total_ahi_events,
@@ -619,7 +621,7 @@ def get_session(
                 (array_agg(s.humidity_level  ORDER BY s.duration_seconds DESC))[1] AS humidity_level,
                 (array_agg(s.temperature_c   ORDER BY s.duration_seconds DESC))[1] AS temperature_c,
                 (array_agg(s.machine_tz      ORDER BY s.duration_seconds DESC))[1] AS machine_tz,
-                NULL AS manufacturer,
+                {manufacturer_select},
                 TRUE AS parser_validated,
                 (array_agg(s.note            ORDER BY s.duration_seconds DESC))[1] AS note,
                 COALESCE((
@@ -1102,28 +1104,30 @@ def _session_detail_response(row, user_id: str, db: Session) -> SessionDetail:
 
 
 def _score_vs_30d_avg(user_id: str, folder_date: date, current_score: int, db: Session) -> float | None:
+    manufacturer_select = _manufacturer_select_expression(db)
+
     rows = db.execute(
-        text("""
+        text(f"""
             SELECT
-                folder_date,
-                SUM(duration_seconds) AS duration_seconds,
-                SUM(total_ahi_events) AS total_ahi_events,
-                AVG(avg_leak) AS avg_leak,
-                BOOL_OR(has_spo2) AS has_spo2,
-                CASE WHEN SUM(duration_seconds) > 0
-                     THEN ROUND((SUM(total_ahi_events) / (SUM(duration_seconds) / 3600.0))::numeric, 2)
+                s.folder_date,
+                SUM(s.duration_seconds) AS duration_seconds,
+                SUM(s.total_ahi_events) AS total_ahi_events,
+                AVG(s.avg_leak) AS avg_leak,
+                BOOL_OR(s.has_spo2) AS has_spo2,
+                CASE WHEN SUM(s.duration_seconds) > 0
+                     THEN ROUND((SUM(s.total_ahi_events) / (SUM(s.duration_seconds) / 3600.0))::numeric, 2)
                      ELSE NULL END AS ahi,
-                AVG(avg_spo2) AS avg_spo2,
-                MIN(min_spo2) AS min_spo2,
-                NULL AS manufacturer,
+                AVG(s.avg_spo2) AS avg_spo2,
+                MIN(s.min_spo2) AS min_spo2,
+                {manufacturer_select},
                 TRUE AS parser_validated
-            FROM sessions
-            WHERE user_id = CAST(:uid AS uuid)
-              AND duration_seconds >= 600
-              AND folder_date >= CAST(:folder_date AS date) - INTERVAL '30 days'
-              AND folder_date < CAST(:folder_date AS date)
-            GROUP BY folder_date
-            ORDER BY folder_date
+            FROM sessions s
+            WHERE s.user_id = CAST(:uid AS uuid)
+              AND s.duration_seconds >= 600
+              AND s.folder_date >= CAST(:folder_date AS date) - INTERVAL '30 days'
+              AND s.folder_date < CAST(:folder_date AS date)
+            GROUP BY s.folder_date
+            ORDER BY s.folder_date
         """),
         {"uid": user_id, "folder_date": folder_date},
     ).mappings().all()
@@ -1157,8 +1161,10 @@ def get_session_by_date(
     db: Session = Depends(get_db),
 ):
     """Get session detail by date (YYYY-MM-DD)."""
+    manufacturer_select = _manufacturer_select_expression(db)
+
     row = db.execute(
-        text("""
+        text(f"""
             WITH night AS (
                 SELECT folder_date, user_id
                 FROM sessions
@@ -1171,6 +1177,7 @@ def get_session_by_date(
                 s.folder_date,
                 0 AS block_index,
                 MIN(s.start_datetime) AS start_datetime,
+                MAX(s.start_datetime + (s.duration_seconds || ' seconds')::interval) AS end_datetime,
                 MIN(s.start_datetime) AS pld_start_datetime,
                 SUM(s.duration_seconds) AS duration_seconds,
                 SUM(s.total_ahi_events) AS total_ahi_events,
@@ -1209,7 +1216,7 @@ def get_session_by_date(
                     ORDER BY s2.duration_seconds DESC
                     LIMIT 1
                 ), ARRAY[]::text[]) AS tags,
-                NULL AS manufacturer,
+                {manufacturer_select},
                 TRUE AS parser_validated
             FROM sessions s
             JOIN night n ON s.folder_date = n.folder_date AND s.user_id = n.user_id

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -134,6 +134,7 @@ export interface SessionSummary {
   folder_date: string
   block_index: number
   start_datetime: string
+  end_datetime: string | null
   duration_seconds: number
   duration_hours: number
   ahi: number | null

--- a/frontend/src/components/EventTimeline.test.tsx
+++ b/frontend/src/components/EventTimeline.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import EventTimeline from './EventTimeline'
+
+describe('EventTimeline', () => {
+  it('keeps events after summed session duration inside the timeline bar', () => {
+    render(
+      <EventTimeline
+        startDatetime="2026-06-02T03:57:00Z"
+        durationSeconds={16440}
+        events={[
+          {
+            id: 1,
+            event_type: 'Hypopnea',
+            onset_seconds: 17400,
+            duration_seconds: null,
+            event_datetime: '2026-06-02T08:47:00Z',
+          },
+        ]}
+      />,
+    )
+
+    const marker = screen.getByRole('button', { name: /hypopnea/i })
+
+    expect(Number.parseFloat(marker.style.left)).toBeLessThanOrEqual(100)
+    expect(Number.parseFloat(marker.style.left) + Number.parseFloat(marker.style.width)).toBeLessThanOrEqual(100)
+  })
+
+  it('positions events against the provided wall-clock domain', () => {
+    const domainStart = new Date('2026-06-02T03:45:00Z').getTime()
+    const domainEnd = new Date('2026-06-02T10:45:00Z').getTime()
+
+    render(
+      <EventTimeline
+        startDatetime="2026-06-02T03:57:00Z"
+        durationSeconds={16440}
+        timeDomain={[domainStart, domainEnd]}
+        events={[
+          {
+            id: 1,
+            event_type: 'Hypopnea',
+            onset_seconds: 17400,
+            duration_seconds: null,
+            event_datetime: '2026-06-02T08:47:00Z',
+          },
+        ]}
+      />,
+    )
+
+    const marker = screen.getByRole('button', { name: /hypopnea/i })
+
+    expect(Number.parseFloat(marker.style.left)).toBeGreaterThan(70)
+    expect(Number.parseFloat(marker.style.left)).toBeLessThan(75)
+  })
+})

--- a/frontend/src/components/EventTimeline.tsx
+++ b/frontend/src/components/EventTimeline.tsx
@@ -7,6 +7,7 @@ interface Props {
   events: EventRecord[]
   durationSeconds: number
   startDatetime: string
+  timeDomain?: [number, number] | null
   selectedEventId?: number | null
   onSelectEvent?: (event: EventRecord) => void
 }
@@ -19,12 +20,17 @@ const EVENT_COLORS: Record<string, string> = {
   'Arousal':           '#6AA136',
 }
 
-function fmtTime(startIso: string, offsetSeconds: number): string {
-  const d = new Date(new Date(startIso).getTime() + offsetSeconds * 1000)
+function fmtTime(ts: number): string {
+  const d = new Date(ts)
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: getDisplayTz() })
 }
 
-export default function EventTimeline({ events, durationSeconds, startDatetime, selectedEventId, onSelectEvent }: Props) {
+function eventTimestamp(event: EventRecord, startTs: number): number {
+  const ts = new Date(event.event_datetime).getTime()
+  return Number.isFinite(ts) ? ts : startTs + event.onset_seconds * 1000
+}
+
+export default function EventTimeline({ events, durationSeconds, startDatetime, timeDomain, selectedEventId, onSelectEvent }: Props) {
   const [activeTooltip, setActiveTooltip] = useState<{
     eventType: string
     timeLabel: string
@@ -41,6 +47,24 @@ export default function EventTimeline({ events, durationSeconds, startDatetime, 
     )
   }
 
+  const startTs = new Date(startDatetime).getTime()
+  const fallbackStartTs = Number.isFinite(startTs) ? startTs : 0
+  const eventRanges = events.map((event) => {
+    const ts = eventTimestamp(event, fallbackStartTs)
+    return [ts, ts + (event.duration_seconds ?? 0) * 1000] as [number, number]
+  })
+  const requestedDomainStart = timeDomain?.[0]
+  const requestedDomainEnd = timeDomain?.[1]
+  const domainStart = Math.min(
+    Number.isFinite(requestedDomainStart) ? requestedDomainStart! : fallbackStartTs,
+    ...eventRanges.map(([start]) => start),
+  )
+  const domainEnd = Math.max(
+    Number.isFinite(requestedDomainEnd) ? requestedDomainEnd! : fallbackStartTs + durationSeconds * 1000,
+    ...eventRanges.map(([, end]) => end),
+  )
+  const timelineDurationMs = Math.max(domainEnd - domainStart, 1)
+
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap gap-3 text-xs text-[var(--muted-foreground)]">
@@ -56,7 +80,7 @@ export default function EventTimeline({ events, durationSeconds, startDatetime, 
         <div className="relative mb-2 h-4 text-[10px] text-[var(--muted-foreground)]">
           {[0, 0.25, 0.5, 0.75, 1].map(pct => (
             <span key={pct} className="absolute -translate-x-1/2" style={{ left: `${pct * 100}%` }}>
-              {fmtTime(startDatetime, durationSeconds * pct)}
+              {fmtTime(domainStart + timelineDurationMs * pct)}
             </span>
           ))}
         </div>
@@ -76,15 +100,16 @@ export default function EventTimeline({ events, durationSeconds, startDatetime, 
         <div className="relative h-6 rounded-full bg-[rgba(125,105,93,0.14)]">
           {events.map((evt) => {
             const isSelected = selectedEventId === evt.id
-            const markerStartSeconds = isSelected && evt.duration_seconds
-              ? Math.max(0, evt.onset_seconds - evt.duration_seconds)
-              : evt.onset_seconds
-            const xPct = (markerStartSeconds / durationSeconds) * 100
+            const ts = eventTimestamp(evt, fallbackStartTs)
+            const markerStartTs = isSelected && evt.duration_seconds
+              ? Math.max(domainStart, ts - evt.duration_seconds * 1000)
+              : ts
             const widthPct = evt.duration_seconds
-              ? Math.max((evt.duration_seconds / durationSeconds) * 100, isSelected ? 0.8 : 0.3)
+              ? Math.max((evt.duration_seconds * 1000 / timelineDurationMs) * 100, isSelected ? 0.8 : 0.3)
               : 0.3
+            const xPct = Math.min(Math.max(((markerStartTs - domainStart) / timelineDurationMs) * 100, 0), 100 - widthPct)
             const color = EVENT_COLORS[evt.event_type] ?? '#888'
-            const timeLabel = fmtTime(startDatetime, evt.onset_seconds)
+            const timeLabel = fmtTime(ts)
             const durationLabel = evt.duration_seconds ? `${evt.duration_seconds}s` : 'Duration not available'
             return (
               <button

--- a/frontend/src/pages/SessionDetail.test.tsx
+++ b/frontend/src/pages/SessionDetail.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { setDisplayTz } from '../lib/displayTz'
 import SessionDetail from './SessionDetail'
 
 const apiMock = vi.hoisted(() => ({
@@ -28,6 +29,7 @@ function sessionDetail(machineTz: string | null) {
     folder_date: '2026-06-01',
     block_index: 0,
     start_datetime: '2026-06-02T03:59:51Z',
+    end_datetime: '2026-06-02T09:31:00Z',
     pld_start_datetime: '2026-06-02T03:59:51Z',
     duration_seconds: 4680,
     duration_hours: 1.3,
@@ -99,6 +101,7 @@ function renderSessionDetail() {
 describe('SessionDetail timezone display', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    setDisplayTz('UTC')
     apiMock.getSessionByDate.mockResolvedValue(sessionDetail('America/New_York'))
     apiMock.getEvents.mockResolvedValue([])
     apiMock.getMetrics.mockResolvedValue(emptyMetrics)
@@ -122,5 +125,12 @@ describe('SessionDetail timezone display', () => {
     await waitFor(() => {
       expect(screen.queryByText(/timezone not recorded/i)).not.toBeInTheDocument()
     })
+  })
+
+  it('uses the stored end timestamp instead of adding usage duration to the start', async () => {
+    renderSessionDetail()
+
+    expect(await screen.findByText(/03:59 AM/)).toBeInTheDocument()
+    expect(screen.getByText(/09:31 AM/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -9,6 +9,7 @@ import EventInspector from '../components/EventInspector'
 import EventTimeline from '../components/EventTimeline'
 import InfoPopover from '../components/InfoPopover'
 import MetricsChart from '../components/MetricsChartSplit'
+import { computeMetricsDomain, metricsToPoints } from '../components/metricsChartDomain'
 import SpO2Chart from '../components/SpO2Chart'
 import SessionAICard from '../components/SessionAICard'
 import { Button } from '../components/ui/button'
@@ -320,7 +321,8 @@ export default function SessionDetail() {
 
   const hours = Math.floor(session.duration_seconds / 3600)
   const mins  = Math.floor((session.duration_seconds % 3600) / 60)
-  const endTime = new Date(new Date(session.start_datetime).getTime() + session.duration_seconds * 1000).toISOString()
+  const endTime = session.end_datetime ?? new Date(new Date(session.start_datetime).getTime() + session.duration_seconds * 1000).toISOString()
+  const metricsTimeDomain = computeMetricsDomain(metricsToPoints(metrics))
   const badge = ahiBadge(session.ahi)
   const tagsChanged = !sameTags(tagsDraft, session.tags ?? [])
   const hasDeviceSettings = Boolean(session.therapy_mode || session.mask_type || session.humidity_level != null || session.temperature_c != null)
@@ -513,6 +515,7 @@ export default function SessionDetail() {
                 events={events}
                 durationSeconds={session.duration_seconds}
                 startDatetime={session.start_datetime}
+                timeDomain={metricsTimeDomain}
                 selectedEventId={selectedEventId}
                 onSelectEvent={inspectEvent}
               />

--- a/importer/db.py
+++ b/importer/db.py
@@ -56,6 +56,7 @@ def upsert_session(conn, data: dict) -> int:
     Insert or update a session row. Returns the session's integer id.
     data must contain all columns defined in the sessions table.
     """
+    data.setdefault("manufacturer", None)
     sql = """
     INSERT INTO sessions (
         session_id, folder_date, block_index, start_datetime, pld_start_datetime,
@@ -65,7 +66,7 @@ def upsert_session(conn, data: dict) -> int:
         avg_pressure, p95_pressure, avg_leak, avg_resp_rate, avg_tidal_vol,
         avg_min_vent, avg_snore, avg_flow_lim, has_spo2,
         therapy_mode, mask_type, humidity_level, temperature_c,
-        machine_tz, user_id, updated_at
+        machine_tz, manufacturer, user_id, updated_at
     ) VALUES (
         %(session_id)s, %(folder_date)s, %(block_index)s, %(start_datetime)s, %(pld_start_datetime)s,
         %(duration_seconds)s, %(device_serial)s, %(ahi)s,
@@ -74,7 +75,7 @@ def upsert_session(conn, data: dict) -> int:
         %(avg_pressure)s, %(p95_pressure)s, %(avg_leak)s, %(avg_resp_rate)s, %(avg_tidal_vol)s,
         %(avg_min_vent)s, %(avg_snore)s, %(avg_flow_lim)s, %(has_spo2)s,
         %(therapy_mode)s, %(mask_type)s, %(humidity_level)s, %(temperature_c)s,
-        %(machine_tz)s, %(user_id)s, NOW()
+        %(machine_tz)s, %(manufacturer)s, %(user_id)s, NOW()
     )
     ON CONFLICT (user_id, session_id) DO UPDATE SET
         folder_date             = EXCLUDED.folder_date,
@@ -104,6 +105,7 @@ def upsert_session(conn, data: dict) -> int:
         humidity_level          = EXCLUDED.humidity_level,
         temperature_c           = EXCLUDED.temperature_c,
         machine_tz              = EXCLUDED.machine_tz,
+        manufacturer            = COALESCE(NULLIF(EXCLUDED.manufacturer, ''), NULLIF(sessions.manufacturer, '')),
         -- user_id intentionally excluded: re-import must not change ownership
         updated_at              = NOW()
     RETURNING id

--- a/importer/import_sessions.py
+++ b/importer/import_sessions.py
@@ -238,6 +238,7 @@ def import_folder(folder: Path, folder_date: date, conn, user_id: str):
                 'pld_start_datetime': pld_start,
                 'duration_seconds':   duration_s,
                 'device_serial':      pld_header.device_serial or None,
+                'manufacturer':       'ResMed',
                 'has_spo2':           spo2_data is not None,
                 'therapy_mode':       None,
                 'mask_type':          None,

--- a/importer/sleephq_import.py
+++ b/importer/sleephq_import.py
@@ -561,6 +561,7 @@ def map_machine_date_to_session(record, user_id: str) -> dict:
         "pld_start_datetime": start_datetime,
         "duration_seconds": duration_seconds,
         "device_serial": device_serial,
+        "manufacturer": None,
         "ahi": ahi,
         "central_apnea_count": ca,
         "obstructive_apnea_count": oa,

--- a/migrations/021_add_session_manufacturer.sql
+++ b/migrations/021_add_session_manufacturer.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS manufacturer TEXT;

--- a/schema.sql
+++ b/schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE sessions (
     pld_start_datetime      TIMESTAMPTZ NOT NULL,
     duration_seconds        INTEGER NOT NULL,
     device_serial           TEXT,
+    manufacturer            TEXT,
     ahi                     NUMERIC(6,2),
     central_apnea_count     INTEGER NOT NULL DEFAULT 0,
     obstructive_apnea_count INTEGER NOT NULL DEFAULT 0,

--- a/tests/test_resmed_import_regressions.py
+++ b/tests/test_resmed_import_regressions.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
+from api.therapy_score import compute_therapy_score
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "importer"))
 
 import db as importer_db
@@ -59,6 +61,66 @@ class FakeConn:
 
     def rollback(self):
         self.rollbacks += 1
+
+
+def _session_data(**overrides):
+    data = {
+        "session_id": "20260601_235949",
+        "folder_date": date(2026, 6, 1),
+        "block_index": 0,
+        "start_datetime": datetime(2026, 6, 1, 23, 59, 49, tzinfo=UTC),
+        "pld_start_datetime": datetime(2026, 6, 1, 23, 59, 49, tzinfo=UTC),
+        "duration_seconds": 600,
+        "device_serial": "SN123",
+        "manufacturer": "ResMed",
+        "ahi": 0.0,
+        "central_apnea_count": 0,
+        "obstructive_apnea_count": 0,
+        "hypopnea_count": 0,
+        "apnea_count": 0,
+        "arousal_count": 0,
+        "total_ahi_events": 0,
+        "avg_pressure": None,
+        "p95_pressure": None,
+        "avg_leak": 0.170366,
+        "avg_resp_rate": None,
+        "avg_tidal_vol": None,
+        "avg_min_vent": None,
+        "avg_snore": None,
+        "avg_flow_lim": None,
+        "has_spo2": False,
+        "therapy_mode": None,
+        "mask_type": None,
+        "humidity_level": None,
+        "temperature_c": None,
+        "machine_tz": "UTC",
+        "user_id": "user-1",
+    }
+    data.update(overrides)
+    return data
+
+
+def test_upsert_session_persists_manufacturer_without_null_clobber():
+    conn = FakeConn(rows=[(123,)])
+
+    assert importer_db.upsert_session(conn, _session_data()) == 123
+
+    sql, params = conn.cursor_obj.statements[0]
+    assert "manufacturer" in sql
+    assert "%(manufacturer)s" in sql
+    assert "manufacturer            = COALESCE(NULLIF(EXCLUDED.manufacturer, ''), NULLIF(sessions.manufacturer, ''))" in sql
+    assert params["manufacturer"] == "ResMed"
+
+
+def test_upsert_session_defaults_unknown_manufacturer_to_null():
+    conn = FakeConn(rows=[(123,)])
+    data = _session_data()
+    data.pop("manufacturer")
+
+    assert importer_db.upsert_session(conn, data) == 123
+
+    _sql, params = conn.cursor_obj.statements[0]
+    assert params["manufacturer"] is None
 
 
 def test_dedupe_events_preserves_zero_duration_arousal():
@@ -155,6 +217,44 @@ def test_import_folder_replaces_events_on_repeat_import(monkeypatch, tmp_path):
     assert [len(events) for events in event_calls] == [2, 2]
     assert event_calls[0] == event_calls[1]
     assert len(waveform_calls) == 2
+
+
+def test_resmed_import_folder_sets_manufacturer_and_scores_leak(monkeypatch, tmp_path):
+    folder = tmp_path / "20260601"
+    folder.mkdir()
+    for suffix in ("CSL", "PLD"):
+        (folder / f"20260601_235949_{suffix}.edf").touch()
+
+    upserts = []
+
+    def fake_upsert(_conn, data):
+        upserts.append(dict(data))
+        return 123
+
+    monkeypatch.setattr(import_sessions, "_machine_tz_for_user", lambda _conn, _uid: ("UTC", UTC))
+    monkeypatch.setattr(
+        import_sessions,
+        "parse_pld",
+        lambda _path: (
+            FakeHeader(datetime(2026, 6, 1, 23, 59, 49), num_records=10),
+            {"Leak.2s": [0.170366], "Press.2s": [10.0]},
+        ),
+    )
+    monkeypatch.setattr(import_sessions, "read_header", lambda _path: FakeHeader(datetime(2026, 6, 1, 23, 59, 49)))
+    monkeypatch.setattr(import_sessions, "upsert_session", fake_upsert)
+    monkeypatch.setattr(import_sessions, "replace_session_metrics", lambda *_args: None)
+    monkeypatch.setattr(import_sessions, "replace_session_spo2", lambda *_args: None)
+    monkeypatch.setattr(import_sessions, "replace_session_events", lambda *_args: None)
+    monkeypatch.setattr(import_sessions, "replace_waveforms_for_block", lambda *_args: None)
+
+    assert import_sessions.import_folder(folder, date(2026, 6, 1), FakeConn(), "user-1") == 1
+
+    assert upserts[0]["manufacturer"] == "ResMed"
+    assert upserts[0]["avg_leak"] == 0.1704
+    score = compute_therapy_score({**upserts[0], "parser_validated": True})
+    assert score.components.leak is not None
+    assert score.components.leak.value == 10.22
+    assert score.components.leak.unit == "L/min"
 
 
 def test_import_folder_assigns_repeated_eve_events_to_only_matching_split_block(monkeypatch, tmp_path):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import text
 
 from api.routers.sessions import _build_pdf_report, _manufacturer_select_expression, _mask_device_serial
+from api.therapy_score import compute_therapy_score
 
 
 class _ScalarResult:
@@ -43,9 +44,12 @@ def _seed_session(
     has_spo2: bool = False,
     avg_spo2: float | None = None,
     min_spo2: float | None = None,
+    start_datetime: datetime | None = None,
 ):
     if folder_date is None:
         folder_date = date.today()
+    if start_datetime is None:
+        start_datetime = datetime(2025, 1, 15, 22, 0, 0, tzinfo=UTC)
     session_id = str(uuid.uuid4())
     manufacturer_column = ", manufacturer" if include_manufacturer else ""
     manufacturer_value = ", :manufacturer" if include_manufacturer else ""
@@ -66,7 +70,7 @@ def _seed_session(
         {
             "sid": session_id,
             "fd": folder_date,
-            "start": datetime(2025, 1, 15, 22, 0, 0, tzinfo=UTC),
+            "start": start_datetime,
             "machine_tz": machine_tz,
             "uid": user_id,
             "note": note,
@@ -145,6 +149,56 @@ class TestGetSession:
         assert resp.status_code == 200
         assert resp.json()["score_vs_30d_avg"] is not None
 
+    def test_score_vs_30d_avg_uses_historical_manufacturer(self, client: TestClient, auth_headers, test_user, db):
+        db.execute(text("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS manufacturer TEXT"))
+        previous_date = date(2025, 1, 14)
+        current_date = date(2025, 1, 15)
+        _seed_session(
+            db,
+            test_user["id"],
+            folder_date=previous_date,
+            total_ahi_events=0,
+            avg_leak=0.8,
+            duration_seconds=8 * 3600,
+            manufacturer="ResMed",
+            include_manufacturer=True,
+        )
+        sid = _seed_session(
+            db,
+            test_user["id"],
+            folder_date=current_date,
+            total_ahi_events=0,
+            avg_leak=0.1,
+            duration_seconds=8 * 3600,
+            manufacturer="ResMed",
+            include_manufacturer=True,
+        )
+
+        resp = client.get(f"/sessions/{sid}", headers=auth_headers)
+
+        assert resp.status_code == 200
+        current_score = compute_therapy_score({
+            "ahi": 0,
+            "avg_leak": 0.1,
+            "duration_seconds": 8 * 3600,
+            "has_spo2": False,
+            "avg_spo2": None,
+            "min_spo2": None,
+            "manufacturer": "ResMed",
+            "parser_validated": True,
+        }).total
+        previous_score = compute_therapy_score({
+            "ahi": 0,
+            "avg_leak": 0.8,
+            "duration_seconds": 8 * 3600,
+            "has_spo2": False,
+            "avg_spo2": None,
+            "min_spo2": None,
+            "manufacturer": "ResMed",
+            "parser_validated": True,
+        }).total
+        assert resp.json()["score_vs_30d_avg"] == round(current_score - previous_score, 1)
+
     def test_get_detail_includes_note(self, client: TestClient, auth_headers, test_user, db):
         sid = _seed_session(db, test_user["id"], note="Tried mouth tape")
         resp = client.get(f"/sessions/{sid}", headers=auth_headers)
@@ -199,6 +253,84 @@ class TestGetSession:
         assert resp.status_code == 200
         assert resp.json()["machine_tz"] == "America/New_York"
 
+    def test_get_by_date_uses_latest_block_end_datetime(self, client: TestClient, auth_headers, test_user, db):
+        folder_date = date(2026, 6, 3)
+        _seed_session(
+            db,
+            test_user["id"],
+            folder_date=folder_date,
+            start_datetime=datetime(2026, 6, 3, 3, 57, tzinfo=UTC),
+            duration_seconds=40 * 60,
+        )
+        _seed_session(
+            db,
+            test_user["id"],
+            folder_date=folder_date,
+            start_datetime=datetime(2026, 6, 3, 6, 50, tzinfo=UTC),
+            duration_seconds=101 * 60,
+        )
+
+        resp = client.get(f"/sessions/by-date/{folder_date.isoformat()}", headers=auth_headers)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["start_datetime"] == "2026-06-03T03:57:00Z"
+        assert data["duration_seconds"] == 141 * 60
+        assert data["end_datetime"] == "2026-06-03T08:31:00Z"
+
+    def test_get_by_date_preserves_manufacturer_for_leak_score(self, client: TestClient, auth_headers, test_user, db):
+        db.execute(text("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS manufacturer TEXT"))
+        folder_date = date(2026, 6, 1)
+        _seed_session(
+            db,
+            test_user["id"],
+            folder_date=folder_date,
+            duration_seconds=8 * 3600,
+            total_ahi_events=0,
+            avg_leak=0.170366,
+            manufacturer="ResMed",
+            include_manufacturer=True,
+        )
+        _seed_session(
+            db,
+            test_user["id"],
+            folder_date=folder_date,
+            duration_seconds=3600,
+            total_ahi_events=0,
+            avg_leak=0.170366,
+            manufacturer="",
+            include_manufacturer=True,
+        )
+
+        resp = client.get(f"/sessions/by-date/{folder_date.isoformat()}", headers=auth_headers)
+
+        assert resp.status_code == 200
+        leak = resp.json()["therapy_score"]["components"]["leak"]
+        assert leak["score"] == 29
+        assert leak["max_score"] == 29
+        assert leak["label"] == "Large leak"
+        assert leak["value"] == 10.22
+        assert leak["unit"] == "L/min"
+        assert leak["unavailable_reason"] is None
+
+    def test_get_by_date_unknown_manufacturer_keeps_leak_unavailable(self, client: TestClient, auth_headers, test_user, db):
+        db.execute(text("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS manufacturer TEXT"))
+        folder_date = date(2026, 6, 2)
+        _seed_session(
+            db,
+            test_user["id"],
+            folder_date=folder_date,
+            total_ahi_events=0,
+            avg_leak=0.170366,
+            manufacturer="Unknown",
+            include_manufacturer=True,
+        )
+
+        resp = client.get(f"/sessions/by-date/{folder_date.isoformat()}", headers=auth_headers)
+
+        assert resp.status_code == 200
+        assert resp.json()["therapy_score"]["components"]["leak"] is None
+
 
 class TestExportSessionPdf:
     def test_mask_device_serial(self):
@@ -215,7 +347,7 @@ class TestExportSessionPdf:
         expression = _manufacturer_select_expression(_ColumnExistsDb(True))
 
         assert "array_agg(s.manufacturer ORDER BY s.duration_seconds DESC)" in expression
-        assert "FILTER (WHERE s.manufacturer IS NOT NULL)" in expression
+        assert "FILTER (WHERE s.manufacturer IS NOT NULL AND s.manufacturer <> '')" in expression
         assert "'Unknown'" in expression
 
     def test_pdf_omits_repeated_unavailable_equipment_rows(self):


### PR DESCRIPTION
## Summary

Fixes imported-session correctness issues that affected Session Detail therapy scoring and wall-clock timing.

### What changed

- Preserves `manufacturer` through nightly/by-date session aggregation so manufacturer-aware therapy score rules can run.
- Persists `manufacturer = 'ResMed'` for sessions imported through the ResMed DATALOG/EDF importer path.
- Keeps unknown/generic imports conservative instead of defaulting all sessions to ResMed.
- Prevents re-imports with blank manufacturer values from erasing an existing non-empty manufacturer.
- Adds `sessions.manufacturer` to fresh schema and existing installs via migration.
- Adds `end_datetime` to session detail responses using the latest real block end.
- Updates Session Detail header and Event Timeline to use the true wall-clock session range instead of `start + duration_seconds`, which is wrong for split sessions with gaps.

### Why

The Therapy Score Leak component could show `Unavailable` even when `avg_leak` existed because the by-date/session detail path discarded manufacturer metadata, and imported ResMed sessions were not persisting manufacturer metadata in the first place.

Split-session nights could also show incorrect end times because the UI treated total usage duration as continuous elapsed wall-clock time. For nights with gaps between blocks, `start + duration_seconds` could end hours before the actual final metric/event data.

## Test plan

- `npm --workspace frontend run lint`
- `npm --workspace frontend run typecheck`
- `npm --workspace frontend run build`
- `npm --workspace frontend run test`
- `uv run pytest tests/test_resmed_import_regressions.py tests/test_sessions.py tests/test_therapy_score.py`
- `uv run ruff check api/routers/sessions.py tests/test_sessions.py tests/test_therapy_score.py`
- `docker compose build app`
- `docker compose up -d`
- `curl.exe http://127.0.0.1:8000/health`