### PR TITLE
fix(docker): use workspace lockfile for frontend build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM node:20-bookworm AS frontend-build
+FROM node:22-bookworm AS frontend-build
 
 WORKDIR /build
 
-COPY frontend/package.json frontend/package-lock.json ./frontend/
-RUN cd frontend && npm ci
-
+COPY package.json package-lock.json nx.json tsconfig.base.json ./
 COPY frontend ./frontend
-RUN cd frontend && npm run build
+RUN npm ci
+
+RUN npm run build
 
 
 FROM python:3.12-slim AS runtime


### PR DESCRIPTION
## Summary
- switch Docker frontend build stage to workspace-root npm install
- stop copying nonexistent frontend/package-lock.json
- align Docker frontend builder runtime with Node 22

## Why
PR #112 cannot be updated directly because maintainer modification is disabled on the contributor fork, but the Docker build is failing with:
- 
- 

This branch carries the minimal bypass fix so it can merge independently.

## Verification
- 
- 
> sleeplab@1.2.1 check:workspace-lockfile
> node scripts/check-workspace-lockfile.mjs

Workspace lockfile structure looks valid.
- 
> sleeplab@1.2.1 build
> nx build frontend


> nx run frontend:build  [existing outputs match the cache, left as is]

> npm run build


> frontend@1.2.1 build
> tsc -b && vite build

(node:58492) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
vite v8.0.16 building client environment for production...
[2Ktransforming...[32m✓[39m 623 modules transformed.
rendering chunks...
computing gzip size...
[2mdist/[0m[32mindex.html                    [39m[2m[1m  1.67 kB[0m[0m[2m │ gzip:   0.71 kB[0m
[2mdist/[0m[2massets/[0m[32mlogo-Cd_ctWiL.webp     [39m[2m[1m115.69 kB[0m[0m
[2mdist/[0m[2massets/[0m[32mno-data-1zThrncx.webp  [39m[2m[1m123.42 kB[0m[0m
[2mdist/[0m[2massets/[0m[35mindex-UsJCTr5Y.css     [39m[2m[1m 49.08 kB[0m[0m[2m │ gzip:   9.24 kB[0m
[2mdist/[0m[2massets/[0m[36mindex-WF-vI2Eh.js      [39m[33m[1m808.16 kB[0m[39m[2m │ gzip: 229.86 kB[0m

[plugin builtin:vite-reporter] [33m[1m
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.[0m[39m
✓ built in 313ms



 NX   Successfully ran target build for project frontend

Nx read the output from the cache instead of running the command for 1 out of 1 tasks.
- local Docker build not run here because Docker daemon was unavailable in this environment
